### PR TITLE
fix(backend): production gunicorn + DEBUG off + scoped CORS (P0 security)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,5 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Expose the application port
 EXPOSE 5000
 
-# Command to run the application
-CMD ["python", "run.py"]
+# Run under gunicorn — never the Flask dev server. A single worker keeps
+# one data-generator thread until the generator moves to its own worker
+# process (issue #15).
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "app:create_app()"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,22 +1,24 @@
-import os
 import threading
 from flask import Flask
+from flask_cors import CORS
+from .config import get_config, split_origins
 from .routes import api, main
 from .database import db
 from .services import SensorService
 
 def create_app(test_config=None):
 
-    # Configure the Flask app to use the instance folder for configuration
     app = Flask(__name__, instance_relative_config=True)
 
-    # Load the default configuration
-    if test_config is None:
-        app.config.from_pyfile('config.py', silent=True)
-
-    # Load the test configuration
-    else:
+    # Load the environment-selected config class (defaults to the safe
+    # ProductionConfig); an explicit mapping from the tests overrides it.
+    app.config.from_object(get_config())
+    if test_config is not None:
         app.config.from_mapping(test_config)
+
+    # Scope CORS to the configured frontend origins — never a wildcard.
+    origins = split_origins(app.config.get('CORS_ORIGINS'))
+    CORS(app, resources={r"/api/*": {"origins": origins}})
 
     # Register the routes with the app
     app.register_blueprint(main)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,66 @@
+"""Environment-specific Flask configuration.
+
+Three config classes select behaviour by environment. The default is
+``ProductionConfig`` so that a misconfigured deployment fails safe — the
+Werkzeug debugger and dev server must never ship in a container.
+"""
+import os
+
+
+def split_origins(raw: str | None) -> list[str]:
+    """Parse a comma-separated CORS origin list into a clean list.
+
+    An empty/unset value yields ``[]`` (deny all cross-origin) — never a
+    wildcard.
+    """
+    if not raw:
+        return []
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+class BaseConfig:
+    """Settings shared across every environment."""
+
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///test.db")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    # Comma-separated list of allowed frontend origins (see split_origins).
+    CORS_ORIGINS = os.getenv("CORS_ORIGINS")
+
+
+class DevelopmentConfig(BaseConfig):
+    """Local development — the interactive debugger may be enabled."""
+
+    DEBUG = True
+    CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:4200")
+
+
+class TestingConfig(BaseConfig):
+    """Automated tests — disposable in-memory database, no debugger."""
+
+    TESTING = True
+    DEBUG = False
+    SQLALCHEMY_DATABASE_URI = os.getenv(
+        "TEST_DATABASE_URL", "sqlite:///:memory:"
+    )
+
+
+class ProductionConfig(BaseConfig):
+    """Shipped containers — debugger and dev server forbidden."""
+
+    DEBUG = False
+
+
+CONFIG_MAP: dict[str, type[BaseConfig]] = {
+    "development": DevelopmentConfig,
+    "testing": TestingConfig,
+    "production": ProductionConfig,
+}
+
+DEFAULT_CONFIG = "production"
+
+
+def get_config(name: str | None = None) -> type[BaseConfig]:
+    """Resolve a config class by name, defaulting to the safe production."""
+    selected = name or os.getenv("APP_CONFIG", DEFAULT_CONFIG)
+    return CONFIG_MAP.get(selected, ProductionConfig)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ flask_sqlalchemy~=3.1.1
 psycopg2-binary~=2.9.10
 flask-socketio~=5.1.1
 flask_cors~=5.0.0
+gunicorn~=23.0.0

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,15 +1,17 @@
+"""Local development entrypoint.
+
+The shipped container runs ``gunicorn "app:create_app()"`` instead — this
+module is a convenience for running the dev server locally. The Werkzeug
+debugger is opt-in via ``FLASK_DEBUG`` and must never be enabled in a
+deployed environment.
+"""
 import os
 
 from app import create_app
-from flask_cors import CORS
 
-app = create_app(
-    {
-        'SQLALCHEMY_DATABASE_URI': os.getenv("DATABASE_URL", "sqlite:///test.db"),
-        'SQLALCHEMY_TRACK_MODIFICATIONS': False,
-    }
-)
-CORS(app)
+app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug = os.getenv("FLASK_DEBUG", "false").lower() in ("1", "true", "yes")
+    host = os.getenv("FLASK_RUN_HOST", "127.0.0.1")
+    app.run(host=host, port=5000, debug=debug)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "5000:5000"
     environment:
       - DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/sensordb
+      - APP_CONFIG=production
+      - CORS_ORIGINS=http://localhost:4200
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Phase 1 (P0 security) of the refactor epic #12 — the two Critical/High findings from the 360 audit.

## #13 — Disable Flask debug mode and run under gunicorn
- Added `backend/app/config.py` with `DevelopmentConfig` / `TestingConfig` / `ProductionConfig`. Selection via `APP_CONFIG` env var, **defaulting to `ProductionConfig`** so a misconfigured deploy fails safe (`DEBUG=False`).
- Container `CMD` now runs `gunicorn "app:create_app()"` — no Flask dev server in any shipped image. Single worker for now to keep one data-generator thread until the generator is extracted in #15.
- `run.py` is now a dev-only entrypoint; the debugger is opt-in via `FLASK_DEBUG` and binds `127.0.0.1` by default.
- Added `gunicorn` to `requirements.txt`.

## #14 — Scope CORS to the frontend origin
- Moved `CORS(...)` out of `run.py` **into the app factory** so it actually applies under gunicorn (which calls `create_app()` directly, bypassing `run.py`).
- CORS is scoped to a `CORS_ORIGINS` env var on `/api/*`. Empty/unset → deny all cross-origin; **never `*`**.
- Wired `APP_CONFIG=production` and `CORS_ORIGINS=http://localhost:4200` into `docker-compose.yml`.

## Verification
- `pytest backend/tests/test_factory.py` passes in a clean venv.
- Behavioural check (clean venv): production `DEBUG=False`; `app:create_app()` entrypoint resolves the way gunicorn loads it; request with `Origin: http://localhost:4200` gets that exact origin echoed; request with an evil origin gets **no** `Access-Control-Allow-Origin`; no `*` ever emitted.

## Deliberately out of scope (separate epic issues)
- Module rename `app` → `sensor_api` → #24
- Extract the data generator into its own worker process → #15
- Upgrade/pin the base image (still `python:3.9-slim`) → #21
- Drop runtime `db.create_all()` / Alembic → #22
- API versioning `/api/v1` → #23
- Formal `backend/.env.example` (blocked by `.gitignore` `.env.*` rule) → #26

Closes #13, closes #14
Part of #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)