### PR TITLE
chore(ci): GitHub Actions CI + CodeQL + Dependabot (#19)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Backend Python dependencies
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+
+  # Frontend npm dependencies
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege by default; jobs opt into more only if they need it.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend (ruff + pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check backend
+
+      - name: Test (pytest)
+        run: pytest
+      # NOTE: `mypy --strict` is not gated yet — the backend is not fully
+      # annotated. It joins this job once the type hints land (#24).
+
+  frontend:
+    name: Frontend (build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+      # NOTE: lint (#25) and unit tests (#18) are not gated yet — no
+      # `lint`/`test` script or Karma target exists. They join this job
+      # when those issues land.
+
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -38,7 +38,7 @@ def demo():
 
     try:
         raise BackendError(
-            message=f"My error message",
+            message="My error message",
             context=f"expected {int.__name__}, got {type(1.0).__name__}"
         )
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -32,7 +32,7 @@ def get_all_sensors():
     if not isinstance(limit, int) or limit < 1 or limit > 100:
 
         # Send a 400 Bad Request response
-        abort(400, description=f"The value of 'limit' must be between 1 and 100")
+        abort(400, description="The value of 'limit' must be between 1 and 100")
 
     # Fetch the sensor data from the database
     data = SensorService.fetch_data(limit)

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Developer + CI tooling (not installed into the runtime image).
+-r requirements.txt
+
+pytest~=8.3
+pytest-flask~=1.3
+ruff>=0.8,<0.9
+mypy~=1.13


### PR DESCRIPTION
Phase 2 (P1) of epic #12. **Stacked on #31** (which is stacked on #30). Base is `fix/sensor-worker`; the stack merges p0 → worker → ci, then this retargets to `main`.

## What's gated (all verified green locally)
**`.github/workflows/ci.yml`** — `permissions: contents: read`, concurrency-cancel:
- **backend** — `ruff check backend` + `pytest` (20 passed, <1s). Fixed 2 pre-existing `F541` lint errors so ruff is green.
- **frontend** — `npm ci` + `npm run build` (compiles to `dist/sensor-app` in ~9s).
- **gitleaks** — full-history secret scan. Verified locally: `gitleaks git .` → **72 commits, no leaks**.

**`.github/workflows/codeql.yml`** — CodeQL for `python` + `javascript-typescript`, on PR/push to main + weekly cron; least-privilege per-job `security-events: write`.

**`.github/dependabot.yml`** — weekly updates for pip (`/backend`), npm (`/frontend`), github-actions (`/`).

**`backend/requirements-dev.txt`** — pins the dev/CI toolchain (pytest, pytest-flask, ruff, mypy) so it's reproducible and Dependabot-tracked.

## Deliberately NOT gated yet (would land red — tracked to their issues)
Per the "no allowed-to-fail stages" rule, I only gated what passes today:
- **`mypy --strict`** — backend is unannotated (**62 errors** across 9 files). Joins the backend job once the type hints land → **#24**. (TODO comment in `ci.yml`.)
- **frontend lint** — no `lint` script / ESLint config yet → **#25**.
- **frontend unit tests** — no `test` script / Karma target, and the sole spec is broken → **#18**.

Each is a one-line addition to the workflow when its issue closes.

## Note on test DB
`pytest` runs against the tests' sqlite in-memory DB. Migrating to a real PostgreSQL service in CI (CLAUDE.md §3.1) is a follow-up to the broader testing-convention gap, not part of #19's acceptance.

Closes #19
Part of #12