### PR TITLE
fix(frontend): Karma test target + fixed spec + service/home specs (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,11 @@ jobs:
 
       - name: Build
         run: npm run build
-      # NOTE: lint (#25) and unit tests (#18) are not gated yet — no
-      # `lint`/`test` script or Karma target exists. They join this job
-      # when those issues land.
+
+      - name: Test (karma, headless Chrome)
+        run: npm test
+      # NOTE: lint (#25) is not gated yet — no `lint` script / ESLint
+      # config exists. It joins this job when that issue lands.
 
   gitleaks:
     name: Secret scan (gitleaks)

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -92,6 +92,18 @@
           "options": {
             "buildTarget": "sensor-app:build"
           }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "inlineStyleLanguage": "scss",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
         }
       }
     }

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,37 @@
+// Karma configuration for the Angular Karma + Jasmine test target.
+// See https://karma-runner.github.io/6.4/config/configuration-file.html
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true, // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/sensor-app'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    // Headless, sandbox-free launcher for CI (GitHub-hosted runners).
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu'],
+      },
+    },
+    restartOnFileChange: true,
+  });
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@angular-devkit/build-angular": "^19.0.0",
         "@angular/cli": "^19.0.0",
         "@angular/compiler-cli": "^19.0.0",
+        "@angular/platform-browser-dynamic": "^19.1.3",
         "@types/jasmine": "~5.1.0",
         "@types/node": "^16.11.35",
         "copyfiles": "^2.4.1",
@@ -939,6 +940,25 @@
         "@angular/animations": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/platform-browser-dynamic": {
+      "version": "19.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.1.3.tgz",
+      "integrity": "sha512-rfsHu/+wB8YLPjsHKd/Go0SI8zP2gjMkebUHM9SbvVLXEAkxFubcF2htVKbKu8eTncfEJEXD6+3gRAjh5SLrKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "19.1.3",
+        "@angular/compiler": "19.1.3",
+        "@angular/core": "19.1.3",
+        "@angular/platform-browser": "19.1.3"
       }
     },
     "node_modules/@angular/router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
     "ng": "ng",
     "start": "NG_BUILD_PARALLEL_TS=0 ng serve",
     "build": "ng build",
-    "watch": "ng build --watch --configuration development"
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test --watch=false --browsers=ChromeHeadlessCI",
+    "test:watch": "ng test"
   },
   "private": true,
   "dependencies": {
@@ -24,6 +26,7 @@
     "@angular-devkit/build-angular": "^19.0.0",
     "@angular/cli": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
+    "@angular/platform-browser-dynamic": "^19.1.3",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^16.11.35",
     "copyfiles": "^2.4.1",

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,27 +1,34 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { SensorService } from './sensors.service';
+
+// Stub the service so rendering <app-home> does not trigger a real fetch.
+const sensorServiceStub: Partial<SensorService> = {
+  getAllSensorData: () => Promise.resolve([]),
+};
 
 describe('AppComponent', () => {
-    beforeEach(() => TestBed.configureTestingModule({
-        declarations: [AppComponent],
-    }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [{ provide: SensorService, useValue: sensorServiceStub }],
+    }).compileComponents();
+  });
 
-    it('should create the app', () => {
-        const fixture = TestBed.createComponent(AppComponent);
-        const app = fixture.componentInstance;
-        expect(app).toBeTruthy();
-    });
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
 
-    it(`should have as title 'app'`, () => {
-        const fixture = TestBed.createComponent(AppComponent);
-        const app = fixture.componentInstance;
-        expect(app.title).toEqual('app');
-    });
+  it(`should have the title 'Sensor Dashboard'`, () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    expect(fixture.componentInstance.title).toEqual('Sensor Dashboard');
+  });
 
-    it('should render title', () => {
-        const fixture = TestBed.createComponent(AppComponent);
-        fixture.detectChanges();
-        const compiled = fixture.nativeElement as HTMLElement;
-        expect(compiled.querySelector('h1')?.textContent).toContain('Welcome to app!');
-    });
+  it('should render the home component', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-home')).toBeTruthy();
+  });
 });

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HomeComponent } from './home.component';
+import { SensorService } from '../sensors.service';
+import { SensorData } from '../sensordata';
+
+const rows: SensorData[] = [
+  {
+    id: 1,
+    timestamp: '2026-06-27T00:00:00Z',
+    temperature: 20,
+    humidity: 50,
+    vibration: 0,
+  },
+  {
+    id: 2,
+    timestamp: '2026-06-27T00:00:10Z',
+    temperature: 21,
+    humidity: 51,
+    vibration: 1,
+  },
+];
+
+describe('HomeComponent', () => {
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomeComponent],
+      providers: [
+        {
+          provide: SensorService,
+          useValue: { getAllSensorData: () => Promise.resolve(rows) },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HomeComponent);
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('loads sensor data from the service', async () => {
+    await fixture.whenStable();
+    expect(fixture.componentInstance.sensorDataList).toEqual(rows);
+  });
+
+  it('renders one table row per reading', async () => {
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const tableRows = (fixture.nativeElement as HTMLElement).querySelectorAll(
+      'tbody tr',
+    );
+    expect(tableRows.length).toBe(rows.length);
+  });
+});

--- a/frontend/src/app/sensors.service.spec.ts
+++ b/frontend/src/app/sensors.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { SensorService } from './sensors.service';
+import { SensorData } from './sensordata';
+
+describe('SensorService', () => {
+  let service: SensorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SensorService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('fetches sensor data from the API URL', async () => {
+    const rows: SensorData[] = [
+      {
+        id: 1,
+        timestamp: '2026-06-27T00:00:00Z',
+        temperature: 20,
+        humidity: 50,
+        vibration: 0,
+      },
+    ];
+    const fetchSpy = spyOn(window, 'fetch').and.resolveTo(
+      new Response(JSON.stringify(rows), { status: 200 }),
+    );
+
+    const result = await service.getAllSensorData();
+
+    expect(fetchSpy).toHaveBeenCalledWith(service.url);
+    expect(result).toEqual(rows);
+  });
+
+  it('returns an empty array when the API responds with null', async () => {
+    spyOn(window, 'fetch').and.resolveTo(new Response('null', { status: 200 }));
+
+    const result = await service.getAllSensorData();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,9 @@
+/* To learn more about this file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
Phase 2 (P1) of epic #12. **Stacked on #32** (CI) → base is `chore/ci-pipeline`. Full stack: #30 → #31 → #32 → #18.

## Problem
No `test` target in `angular.json` and no `test` script — `ng test` couldn't run at all. `app.component.spec.ts` asserted the wrong title (`'app'` vs `'Sensor Dashboard'`), a non-existent `<h1>`, and used `declarations` for a standalone component.

## Changes
- **Test target** — `angular.json` `test` (`@angular-devkit/build-angular:karma`), `tsconfig.spec.json`, and `karma.conf.js` with a sandbox-free `ChromeHeadlessCI` launcher for CI runners.
- **Scripts** — `npm test` (`ng test --watch=false --browsers=ChromeHeadlessCI`) and `npm run test:watch` (interactive).
- **Dependency** — added `@angular/platform-browser-dynamic@19.1.3` (devDep, pinned to match `@angular/core`). The Karma builder's auto-generated test bootstrap imports it; the app itself uses `bootstrapApplication`, which is why it was absent.
- **Specs**
  - `app.component.spec.ts` — rewritten: `imports` (standalone), asserts real title + that `<app-home>` renders; stubs `SensorService` so no real `fetch` fires.
  - `sensors.service.spec.ts` — spies `window.fetch`; asserts the API URL is called and the `?? []` empty-fallback.
  - `home.component.spec.ts` — mock service; asserts data loads and one `<tbody>` row renders per reading.
- **CI** — `npm test` now gated in the frontend job (replaces the #18 deferral TODO from #32).

## Verification
- Local headless Chrome: **9 specs, 9 SUCCESS**.
- CI on this PR will run `npm ci && npm run build && npm test` on ubuntu-latest (Chrome preinstalled) — see checks below.

## Note on coupling with #16
`SensorService` still uses `fetch` and `HomeComponent` loads in its constructor — **#16** will move these to `HttpClient` + `ngOnInit` + loading/empty/error states, which will revise these specs accordingly. The test *infrastructure* (target, config, scripts, CI gate) is permanent; the spec *bodies* track the service/component design.

Closes #18
Part of #12