### PR TITLE
refactor(backend): standalone sensor worker + deterministic tests (#15, #20)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Expose the application port
 EXPOSE 5000
 
-# Run under gunicorn — never the Flask dev server. A single worker keeps
-# one data-generator thread until the generator moves to its own worker
-# process (issue #15).
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "app:create_app()"]
+# Run under gunicorn — never the Flask dev server. The data generator runs
+# as a separate worker service, so multiple web workers are safe; tune with
+# the WEB_CONCURRENCY env var (gunicorn reads it).
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:create_app()"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,10 +1,8 @@
-import threading
 from flask import Flask
 from flask_cors import CORS
 from .config import get_config, split_origins
 from .routes import api, main
 from .database import db
-from .services import SensorService
 
 def create_app(test_config=None):
 
@@ -27,17 +25,11 @@ def create_app(test_config=None):
     # Initialize the database
     db.init_app(app)
 
-    # Create the database tables
+    # Create the database tables. This stays until Alembic migrations land
+    # (#22); the factory must otherwise do wiring only. The sensor data
+    # generator runs as a separate worker process (worker.py), never a
+    # thread spawned here.
     with app.app_context():
         db.create_all()
-
-    # Start the sensor data generation thread
-    with app.app_context():
-        sensor_thread = threading.Thread(
-            target=SensorService.generate_data,
-            args=(app,)
-        )
-        sensor_thread.daemon = True
-        sensor_thread.start()
 
     return app

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -1,38 +1,47 @@
 from .models import SensorData
 from .database import db
 from .sensors import AnalogSensor, DiscreteSensor
-import time
 
 
 class SensorService(object):
     """Service class for handling sensor data."""
 
     @staticmethod
-    def generate_data(app):
-        """Thread to generate sensor data and store it in the database."""
+    def build_sensors():
+        """Construct the simulated field sensors.
 
-        # Create the simulated field sensors
-        temperature = AnalogSensor('temperature')
-        humidity = AnalogSensor('humidity')
-        vibration = DiscreteSensor('vibration')
+        Built once by the worker and reused across samples so each sensor
+        keeps its own state between readings.
+        """
+        return (
+            AnalogSensor('temperature'),
+            AnalogSensor('humidity'),
+            DiscreteSensor('vibration'),
+        )
 
-        # Thread loop
-        while True:
+    @staticmethod
+    def record_reading(sensors):
+        """Sample the sensors and persist a single reading.
 
-            # Sample time is fixed to 10 seconds
-            time.sleep(10)
+        Requires an active app context. On failure the session is rolled
+        back so it is never left poisoned, and the error is re-raised for
+        the caller to log.
+        """
+        temperature, humidity, vibration = sensors
+        reading = SensorData(
+            temperature=temperature.read(),
+            humidity=humidity.read(),
+            vibration=vibration.read()
+        )
 
-            # Map the readings to the database model
-            sensor_data = SensorData(
-                temperature=temperature.read(),
-                humidity=humidity.read(),
-                vibration=vibration.read()
-            )
+        try:
+            db.session.add(reading)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise
 
-            # Store the readings in the database
-            with app.app_context():
-                db.session.add(sensor_data)
-                db.session.commit()
+        return reading
 
     @staticmethod
     def fetch_data(limit=100):

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,7 +1,14 @@
-import time
 import unittest
 from backend.app import create_app
 from backend.app.database import db
+from backend.app.models import SensorData
+
+
+def _reading(temperature=20.0, humidity=50.0, vibration=0):
+    """Build a SensorData row for seeding tests directly."""
+    return SensorData(
+        temperature=temperature, humidity=humidity, vibration=vibration
+    )
 
 
 class FlaskRouteTestCase(unittest.TestCase):
@@ -26,7 +33,6 @@ class FlaskRouteTestCase(unittest.TestCase):
         db.session.remove()
         db.drop_all()
         cls.app_context.pop()
-        time.sleep(1)
 
     def setUp(self):
         """Run before each test."""
@@ -49,40 +55,32 @@ class FlaskRouteTestCase(unittest.TestCase):
         response = self.client.get('/notfound')
         self.assertEqual(404, response.status_code)
 
-    def test_api_sensors_route(self):
-        """Test the api/sensors route."""
+    def test_api_sensors_returns_seeded_rows(self):
+        """All seeded readings are returned by default."""
+        db.session.add_all([_reading(), _reading(vibration=1)])
+        db.session.commit()
 
-        # Wait for the first reading to be generated
-        time.sleep(11)
-
-        # Get the first reading
         response = self.client.get('/api/sensors')
         self.assertEqual(200, response.status_code)
+        self.assertEqual(2, len(response.get_json()))
 
-        # Check the response length
-        sample_01 = response.get_json()
-        self.assertEqual(1, len(sample_01))
-
-        # Wait for another reading to be generated
-        time.sleep(11)
-
-        # Get the next reading
+    def test_api_sensors_empty_returns_empty_list(self):
+        """With no data the route returns 200 and an empty list."""
         response = self.client.get('/api/sensors')
         self.assertEqual(200, response.status_code)
+        self.assertEqual([], response.get_json())
 
-        # Check the response length
-        sample_02 = response.get_json()
-        self.assertEqual(2, len(sample_02))
+    def test_api_sensors_limit_caps_results(self):
+        """The limit query parameter caps the number of rows returned."""
+        db.session.add_all([_reading() for _ in range(3)])
+        db.session.commit()
 
-        # Get a new reading with a limit
         response = self.client.get('/api/sensors?limit=1')
         self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.get_json()))
 
-        # Check the response length
-        sample_03 = response.get_json()
-        self.assertEqual(1, len(sample_03))
-
-        # Test the limit query parameter
-        for test_val in (-1, 101):
+    def test_api_sensors_limit_out_of_range_returns_400(self):
+        """A limit outside the 1-100 bounds is rejected with 400."""
+        for test_val in (-1, 0, 101):
             response = self.client.get(f'/api/sensors?limit={test_val}')
             self.assertEqual(400, response.status_code)

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,45 @@
+"""Standalone sensor data generator.
+
+Runs as its own process — NOT a thread inside ``create_app`` — so there is
+exactly one generator regardless of how many gunicorn workers serve the
+API, and none runs during tests or under the dev reloader. It owns its own
+app context and DB session, and rolls back on a failed insert.
+
+Run locally:   python worker.py
+In compose:    command: ["python", "worker.py"]
+"""
+import logging
+import os
+import time
+
+from app import create_app
+from app.services import SensorService
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+log = logging.getLogger("sensor.worker")
+
+# Sample interval in seconds — env-configurable, defaults to 10s.
+SAMPLE_INTERVAL_SECONDS = int(os.getenv("SAMPLE_INTERVAL_SECONDS", "10"))
+
+
+def run() -> None:
+    """Generate and persist a sensor reading every sample interval."""
+    app = create_app()
+    sensors = SensorService.build_sensors()
+    log.info("sensor worker started; interval=%ss", SAMPLE_INTERVAL_SECONDS)
+
+    with app.app_context():
+        while True:
+            try:
+                reading = SensorService.record_reading(sensors)
+                log.info("recorded sensor reading id=%s", reading.id)
+            except Exception:
+                log.exception("failed to record sensor reading")
+            time.sleep(SAMPLE_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    run()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,19 @@ services:
       db:
         condition: service_healthy
 
+  worker:
+    build:
+      context: ./backend
+    command: ["python", "worker.py"]
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/sensordb
+      - APP_CONFIG=production
+      - SAMPLE_INTERVAL_SECONDS=10
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
   frontend:
     build:
       context: ./frontend


### PR DESCRIPTION
Replaces #31, which GitHub auto-closed when its base branch (`fix/p0-debug-cors-gunicorn`) was deleted on merge of #30. Same commits, now targeting `main` directly.

## #15 — Generator out of the app factory, into a dedicated worker
- Daemon generator thread removed from `create_app` (it duplicated under multi-worker gunicorn, doubled under the dev reloader, ran during tests, shared the global session with no rollback).
- New `backend/worker.py`: standalone process, own app context + session, `SAMPLE_INTERVAL_SECONDS` (default 10s), per-insert rollback.
- `SensorService.generate_data` → `build_sensors()` + `record_reading()`.
- `worker` service added to docker-compose; web Dockerfile drops the single-worker pin.

## #20 — Deterministic, clean-clone tests
- Route tests seed `SensorData` directly (no `time.sleep`); suite ~22s → <1s. Added empty-list + limit-cap cases.

The runtime `db.create_all()` stays until Alembic lands (#22).

Closes #15, closes #20
Part of #12