### PR TITLE
feat(frontend): HttpClient + loading/empty/error states + env URL (#16)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,9 @@ services:
       context: ./frontend
     ports:
       - "4200:4200"
-    environment:
-      - REACT_APP_BACKEND_URL=http://localhost:5000
+    # The API base URL is a build-time setting in src/environments/*, not a
+    # runtime env var (the old REACT_APP_BACKEND_URL was a React var, never
+    # read by this Angular app).
     depends_on:
       - backend
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -53,6 +53,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { AppComponent } from './app.component';
 import { SensorService } from './sensors.service';
 
-// Stub the service so rendering <app-home> does not trigger a real fetch.
+// Stub the service so rendering <app-home> does not trigger a real request.
 const sensorServiceStub: Partial<SensorService> = {
-  getAllSensorData: () => Promise.resolve([]),
+  getAllSensorData: () => of([]),
 };
 
 describe('AppComponent', () => {

--- a/frontend/src/app/home/home.component.css
+++ b/frontend/src/app/home/home.component.css
@@ -14,3 +14,15 @@ th, td {
 th {
     background-color: #f4f4f4;
 }
+
+.status {
+    margin: 20px 0;
+    font-style: italic;
+    color: #555;
+}
+
+.status-error {
+    color: #b00020;
+    font-style: normal;
+    font-weight: 600;
+}

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable, Subject, of, throwError } from 'rxjs';
 import { HomeComponent } from './home.component';
 import { SensorService } from '../sensors.service';
 import { SensorData } from '../sensordata';
@@ -20,37 +21,72 @@ const rows: SensorData[] = [
   },
 ];
 
-describe('HomeComponent', () => {
-  let fixture: ComponentFixture<HomeComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HomeComponent],
-      providers: [
-        {
-          provide: SensorService,
-          useValue: { getAllSensorData: () => Promise.resolve(rows) },
-        },
-      ],
-    }).compileComponents();
-    fixture = TestBed.createComponent(HomeComponent);
+function createFixture(
+  getAllSensorData: () => Observable<SensorData[]>,
+): ComponentFixture<HomeComponent> {
+  TestBed.configureTestingModule({
+    imports: [HomeComponent],
+    providers: [{ provide: SensorService, useValue: { getAllSensorData } }],
   });
+  return TestBed.createComponent(HomeComponent);
+}
 
+function text(fixture: ComponentFixture<HomeComponent>): string {
+  return (fixture.nativeElement as HTMLElement).textContent ?? '';
+}
+
+describe('HomeComponent', () => {
   it('should create', () => {
+    const fixture = createFixture(() => of(rows));
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('loads sensor data from the service', async () => {
-    await fixture.whenStable();
-    expect(fixture.componentInstance.sensorDataList).toEqual(rows);
-  });
+  it('renders one table row per reading on success', () => {
+    const fixture = createFixture(() => of(rows));
+    fixture.detectChanges(); // runs ngOnInit
 
-  it('renders one table row per reading', async () => {
-    await fixture.whenStable();
-    fixture.detectChanges();
     const tableRows = (fixture.nativeElement as HTMLElement).querySelectorAll(
       'tbody tr',
     );
     expect(tableRows.length).toBe(rows.length);
+    expect(fixture.componentInstance.loading).toBeFalse();
+    expect(fixture.componentInstance.error).toBeFalse();
+  });
+
+  it('shows the loading state until data arrives', () => {
+    // A subject that never emits keeps the component in its loading state.
+    const fixture = createFixture(() => new Subject<SensorData[]>());
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.loading).toBeTrue();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[role="status"]'),
+    ).toBeTruthy();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('table'),
+    ).toBeNull();
+  });
+
+  it('shows the empty state when no readings are returned', () => {
+    const fixture = createFixture(() => of([]));
+    fixture.detectChanges();
+
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('table'),
+    ).toBeNull();
+    expect(text(fixture)).toContain('No sensor data');
+  });
+
+  it('shows the error state when the request fails', () => {
+    const fixture = createFixture(() => throwError(() => new Error('boom')));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.error).toBeTrue();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[role="alert"]'),
+    ).toBeTruthy();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('table'),
+    ).toBeNull();
   });
 });

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -1,7 +1,8 @@
-import {Component, inject} from '@angular/core';
+import {Component, OnInit, inject} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {catchError, of} from 'rxjs';
 import {SensorService} from '../sensors.service';
-import {SensorData} from "../sensordata";
+import {SensorData} from '../sensordata';
 
 @Component({
   selector: 'app-home',
@@ -10,18 +11,28 @@ import {SensorData} from "../sensordata";
   /**
    * HomeComponent displays the latest sensor data in a table.
    *
-   * This component fetches sensor data from the SensorService when it is created.
-   * The data is then displayed in a table and sorted by timestamp, with the most
-   * recent data at the top.
+   * Data is loaded once in ngOnInit via the SensorService. The view renders
+   * explicit loading, error, and empty states so a failed or empty response
+   * never leaves a silent blank table.
    */
 
   template: `
     <section class="results">
-      
+
       <h2>Latest Sensor Data (Hit F5 to refresh, new data every 10 seconds)</h2>
-      
-      <table>
-        
+
+      <p *ngIf="loading" class="status" role="status">Loading sensor data…</p>
+
+      <p *ngIf="error" class="status status-error" role="alert">
+        Could not load sensor data. Please try again later.
+      </p>
+
+      <p *ngIf="!loading && !error && sensorDataList.length === 0" class="status">
+        No sensor data available yet.
+      </p>
+
+      <table *ngIf="!loading && !error && sensorDataList.length > 0">
+
         <thead>
           <tr>
             <th>Timestamp</th>
@@ -30,7 +41,7 @@ import {SensorData} from "../sensordata";
             <th>Vibration</th>
           </tr>
         </thead>
-        
+
         <tbody>
           <tr *ngFor="let sensor of sensorDataList">
             <td>{{ sensor.timestamp }}</td>
@@ -40,29 +51,36 @@ import {SensorData} from "../sensordata";
           </tr>
         </tbody>
       </table>
-      
+
     </section>
   `,
   styleUrls: ['./home.component.css'],
 })
-
-export class HomeComponent {
+export class HomeComponent implements OnInit {
 
   // List of sensor data
   sensorDataList: SensorData[] = [];
 
-  // Inject the sensor service
-  sensorService: SensorService = inject(SensorService);
+  // View state flags
+  loading = true;
+  error = false;
 
-  // When the component is created, get all sensor data
-  constructor() {
-    this.sensorService.getAllSensorData().then((sensorDataList: SensorData[]) => {
-      this.sensorDataList = sensorDataList;
-    });
+  // Inject the sensor service
+  private readonly sensorService = inject(SensorService);
+
+  // Load data once when the component initializes
+  ngOnInit(): void {
+    this.sensorService
+      .getAllSensorData()
+      .pipe(
+        catchError(() => {
+          this.error = true;
+          return of([] as SensorData[]);
+        }),
+      )
+      .subscribe((sensorDataList: SensorData[]) => {
+        this.sensorDataList = sensorDataList;
+        this.loading = false;
+      });
   }
 }
-
-
-
-
-

--- a/frontend/src/app/sensors.service.spec.ts
+++ b/frontend/src/app/sensors.service.spec.ts
@@ -1,20 +1,34 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import { SensorService } from './sensors.service';
 import { SensorData } from './sensordata';
+import { environment } from '../environments/environment';
 
 describe('SensorService', () => {
   let service: SensorService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
     service = TestBed.inject(SensorService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('fetches sensor data from the API URL', async () => {
+  it('GETs sensor data from the configured API URL', () => {
     const rows: SensorData[] = [
       {
         id: 1,
@@ -24,21 +38,29 @@ describe('SensorService', () => {
         vibration: 0,
       },
     ];
-    const fetchSpy = spyOn(window, 'fetch').and.resolveTo(
-      new Response(JSON.stringify(rows), { status: 200 }),
-    );
 
-    const result = await service.getAllSensorData();
+    let result: SensorData[] | undefined;
+    service.getAllSensorData().subscribe((data) => (result = data));
 
-    expect(fetchSpy).toHaveBeenCalledWith(service.url);
+    const req = httpMock.expectOne(environment.apiUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush(rows);
+
     expect(result).toEqual(rows);
   });
 
-  it('returns an empty array when the API responds with null', async () => {
-    spyOn(window, 'fetch').and.resolveTo(new Response('null', { status: 200 }));
+  it('propagates an error response to the caller', () => {
+    let errored = false;
+    service.getAllSensorData().subscribe({
+      next: () => {},
+      error: () => (errored = true),
+    });
 
-    const result = await service.getAllSensorData();
+    httpMock.expectOne(environment.apiUrl).flush('fail', {
+      status: 500,
+      statusText: 'Server Error',
+    });
 
-    expect(result).toEqual([]);
+    expect(errored).toBeTrue();
   });
 });

--- a/frontend/src/app/sensors.service.ts
+++ b/frontend/src/app/sensors.service.ts
@@ -1,22 +1,26 @@
-import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Injectable, inject} from '@angular/core';
+import {Observable} from 'rxjs';
+import {environment} from '../environments/environment';
 import {SensorData} from './sensordata';
 
 @Injectable({
   providedIn: 'root',
 })
-
 export class SensorService {
   /**
-   * Fetches all sensor data from the API.
+   * Fetches sensor data from the backend API over HttpClient.
    *
-   * @returns A promise that resolves to an array of SensorData objects.
+   * Errors are intentionally not swallowed here — callers handle them with
+   * `catchError` so they can render an explicit error state.
    */
 
-  // The URL of the sensor data API */
-  readonly url = 'http://localhost:5000/api/sensors';
+  private readonly http = inject(HttpClient);
 
-  async getAllSensorData(): Promise<SensorData[]> {
-    const data = await fetch(this.url);
-    return (await data.json()) ?? [];
+  // The sensors endpoint, from the build-time environment config.
+  readonly url = environment.apiUrl;
+
+  getAllSensorData(): Observable<SensorData[]> {
+    return this.http.get<SensorData[]>(this.url);
   }
 }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,7 @@
+// Production environment. Uses a same-origin relative path so the static
+// frontend can be served behind a reverse proxy that forwards /api to the
+// backend (see the nginx setup in #17 / deployment in #29).
+export const environment = {
+  production: true,
+  apiUrl: '/api/sensors',
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,7 @@
+// Default (development) environment. Replaced by environment.prod.ts in
+// production builds via the fileReplacements in angular.json.
+export const environment = {
+  production: false,
+  // Backend sensors endpoint. The dev backend is exposed on localhost:5000.
+  apiUrl: 'http://localhost:5000/api/sensors',
+};

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,8 +3,9 @@
  *  Protractor is used in this example for compatibility with Angular documentation tools.
  */
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
+import {provideHttpClient, withFetch} from '@angular/common/http';
 import {AppComponent} from './app/app.component';
 
-bootstrapApplication(AppComponent, {providers: [provideProtractorTestingSupport()]}).catch((err) =>
-  console.error(err),
-);
+bootstrapApplication(AppComponent, {
+  providers: [provideProtractorTestingSupport(), provideHttpClient(withFetch())],
+}).catch((err) => console.error(err));


### PR DESCRIPTION
Phase 2 (P1) of epic #12. Branches off `main` (clean, CI-gated — no stacking).

## Problem
`SensorService` used raw `fetch` with a hardcoded `http://localhost:5000` URL and no error handling, so a failed or empty response left a **silent blank table**. The compose `REACT_APP_BACKEND_URL` was a React var never read by this Angular app.

## Changes
- **HttpClient** — `SensorService.getAllSensorData()` now returns `Observable<SensorData[]>` via `HttpClient`; `provideHttpClient(withFetch())` registered in `main.ts`.
- **Env-based URL** — `src/environments/environment.ts` (dev → `http://localhost:5000/api/sensors`) and `environment.prod.ts` (prod → same-origin `/api/sensors`), wired via `fileReplacements` in the production build config.
- **Explicit states** — `HomeComponent` loads in `ngOnInit` (not the constructor) and renders **loading** (`role="status"`), **error** (`role="alert"`, via `catchError`), and **empty** states alongside the data table.
- **Cleanup** — removed the dead `REACT_APP_BACKEND_URL` from `docker-compose.yml`.
- **Specs** — SensorService via `HttpClientTesting` (URL called + error propagation); HomeComponent covers all four states (loading/empty/error/data); AppComponent stub returns an Observable.

## Verification (local)
- Prod build clean (142.88 kB, within budget); **grep confirms no `localhost:5000` in the prod bundle** → `fileReplacements` swapped correctly.
- **11 specs pass** in headless Chrome (3 app + 3 service + 5 home).

## Scope boundaries (left for their issues)
- Formatting pipes (`| number`, `| date`), vibration legend, table `<caption>`/`scope` a11y → **#25**.
- API versioning to `/api/v1/sensors` → **#23** (env URL tracks the current `/api/sensors`).
- Polling/real-time → enhancement **#8**.

Closes #16
Part of #12