### PR TITLE
chore(infra): pin/upgrade images + harden docker-compose (#21)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
-# Base image
-FROM python:3.9-slim
+# Base image — pinned, current (3.9 reached EOL Oct 2025).
+FROM python:3.12-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/')"]
+      interval: 10s
+      retries: 5
+      start_period: 15s
+      timeout: 5s
 
   worker:
     build:
@@ -25,6 +32,13 @@ services:
       db:
         condition: service_healthy
     restart: unless-stopped
+    # Liveness: confirm the worker process (PID 1) is still running.
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q worker.py /proc/1/cmdline"]
+      interval: 30s
+      retries: 3
+      start_period: 10s
+      timeout: 5s
 
   frontend:
     build:
@@ -35,18 +49,29 @@ services:
     # runtime env var (the old REACT_APP_BACKEND_URL was a React var, never
     # read by this Angular app).
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:4200/ || exit 1"]
+      interval: 15s
+      retries: 5
+      # ng serve compiles on first boot, so allow generous start-up time.
+      start_period: 60s
+      timeout: 5s
 
   db:
-    image: postgres:13
+    image: postgres:16
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: sensordb
-    ports:
-      - "5432:5432"
+    # The DB port is intentionally not published to the host. Services reach
+    # it over the compose network as db:5432; for host access use
+    # `docker compose exec db psql -U postgres -d sensordb`.
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres", "-d", "sensordb"]
       interval: 10s

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
-# Use the official Node.js image as the base image
-FROM node:alpine
+# Use the official Node.js image as the base image — pinned, not floating.
+# (The multi-stage nginx production build is handled in #17.)
+FROM node:22-alpine
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Phase 2 (P1) of epic #12. Branches off `main`.

## Problem
`python:3.9-slim` (EOL Oct 2025), `postgres:13` (EOL Nov 2025), floating `node:alpine`; only `db` had a healthcheck; no `restart` policies; `5432` published to the host.

## Changes
- **Images** — backend `python:3.9-slim → 3.12-slim`, frontend `node:alpine → node:22-alpine`, db `postgres:13 → 16`.
- **Healthchecks + `restart: unless-stopped` on every service:**
  - backend — `urllib` GET to `/`
  - worker — PID‑1 liveness (`grep -q worker.py /proc/1/cmdline`)
  - frontend — `wget` to `/` (generous 60s `start_period` for ng‑serve compile)
  - db — keeps `pg_isready`
- **Dependencies** — frontend now `depends_on: backend: condition: service_healthy` (backend/worker already gated on db).
- **DB port unpublished** — removed `5432:5432`; reachable internally as `db:5432`, or `docker compose exec db psql` for host access.

## Verification
- `docker compose config --quiet` → **valid (exit 0)**; resolved config confirms `postgres:16`, `restart` + healthcheck on all four services, `service_healthy` deps, and **no published port on db** (only 5000/4200 publish).
- The Docker **engine wasn't running here**, so images weren't built/run; but the **Python 3.12** and **Node 22** toolchains are already exercised green by CI (pytest on 3.12, `npm ci`/build on node 22 locally).

## Notes / scope
- Frontend stays `ng serve` (dev) — the **multi-stage nginx production image is #17**; this PR only pins its base.
- CI doesn't build Docker images, so it won't exercise these files (no docker-build job — possible future addition). Local `compose config` is the validation here.
- DB credentials remain literals (`postgres/postgres`) for the local demo; moving them to env/secrets is a broader follow-up (compose `.env`), not part of #21's acceptance.

Closes #21
Part of #12