### PR TITLE
chore(frontend): multi-stage Docker served by nginx (#17)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,21 +43,20 @@ services:
   frontend:
     build:
       context: ./frontend
+    # nginx serves the production bundle on port 80 and proxies /api to the
+    # backend (see frontend/nginx.conf). The API base URL is a build-time
+    # setting in src/environments/* — not a runtime env var.
     ports:
-      - "4200:4200"
-    # The API base URL is a build-time setting in src/environments/*, not a
-    # runtime env var (the old REACT_APP_BACKEND_URL was a React var, never
-    # read by this Angular app).
+      - "4200:80"
     depends_on:
       backend:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:4200/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:80/ || exit 1"]
       interval: 15s
       retries: 5
-      # ng serve compiles on first boot, so allow generous start-up time.
-      start_period: 60s
+      start_period: 10s
       timeout: 5s
 
   db:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,25 @@
-# Use the official Node.js image as the base image — pinned, not floating.
-# (The multi-stage nginx production build is handled in #17.)
-FROM node:22-alpine
+# --- Build stage: compile the Angular app ---
+FROM node:22-alpine AS build
 
-# Set the working directory inside the container
 WORKDIR /app
 
-# Copy all the files from the frontend directory to the working directory
-COPY . .
-
-# Install angular-cli globally
-RUN npm install -g @angular/cli
-
-# Install the dependencies (reproducible: requires committed package-lock.json)
+# Install dependencies first for better layer caching (deps change rarely).
+COPY package.json package-lock.json ./
 RUN npm ci
 
-# Expose the port that the application will run on
-EXPOSE 4200
+# Build the production bundle (ng build defaults to the production config,
+# which swaps in environment.prod.ts -> same-origin /api/sensors).
+COPY . .
+RUN npm run build
 
-# Start the application in development mode
-CMD ["ng", "serve", "--host", "0.0.0.0"]
+# --- Runtime stage: serve the static bundle via nginx ---
+FROM nginx:1.27-alpine
+
+# SPA routing + /api reverse proxy to the backend service.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# The Angular application builder emits static assets under browser/.
+COPY --from=build /app/dist/sensor-app/browser /usr/share/nginx/html
+
+EXPOSE 80
+# nginx:alpine already runs `nginx -g 'daemon off;'` as its CMD.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing: fall back to index.html so the Angular router handles
+    # client-side routes instead of returning 404.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Reverse-proxy API calls to the backend service. This keeps the browser
+    # on a single origin (no CORS needed) and matches the production
+    # environment's relative /api/sensors URL. The backend must be reachable
+    # as `backend:5000` on the same network (docker-compose).
+    location /api/ {
+        proxy_pass http://backend:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
Phase 2 (P1) of epic #12 — the last P1. Branches off `main`.

## Problem
`frontend/Dockerfile` shipped `ng serve` (the dev server) as production.

## Changes
- **Multi-stage Dockerfile**
  - build stage: `node:22-alpine` → `npm ci` + `npm run build` (production config; swaps in `environment.prod.ts`)
  - runtime stage: pinned `nginx:1.27-alpine` serving the static bundle — **no dev server in the image**
- **`frontend/nginx.conf`** — SPA fallback (`try_files … /index.html`) + a `/api` reverse proxy to `backend:5000`. This keeps the browser **same-origin** (no CORS) and makes the production relative `/api/sensors` URL from #16 resolve.
- Serves the application builder's `dist/sensor-app/browser` output.
- **Compose** — frontend publishes host **4200 → container 80** and healthchecks nginx on `:80` (start-up dropped 60s → 10s since nginx serves instantly).

## Verification
- `docker compose config --quiet` → valid; resolved config shows `4200:80` + healthcheck + `depends_on backend service_healthy`.
- Build output path confirmed: `dist/sensor-app/browser/index.html` exists (matches the Dockerfile COPY).
- The production `npm run build` (the build stage's command) is **CI-green**.

## ⚠️ Not runtime-verified
The Docker **engine was unavailable** in this environment, so the image build and nginx serving (proxy + SPA fallback) were **not run end-to-end**. The build stage is CI-covered; the nginx layer is a standard SPA+proxy config reviewed by hand. **Recommend a `docker compose up` smoke test** before relying on it (happy to do it once the engine is up, or it can be a follow-up docker-build CI job).

## Notes
- nginx resolves `backend` at startup; `depends_on: service_healthy` guarantees it's up first. If the backend container is later recreated with a new IP, nginx would need a reload (acceptable for the demo; a `resolver` + variable is the robust fix if needed).

Closes #17
Part of #12