### PR TITLE
docs: dev journal + ADRs for the P0/P1 refactor session

### DIFF
--- a/docs/decisions/0001-data-generator-as-worker-process.md
+++ b/docs/decisions/0001-data-generator-as-worker-process.md
@@ -1,0 +1,24 @@
+# ADR-0001 — Data generator runs as a dedicated worker process
+
+**Status:** Accepted (2026-06-27, PR #34, issue #15)
+
+## Context
+The sensor data generator ran as a daemon `threading.Thread` started inside
+`create_app()`. That meant a generator per gunicorn worker (duplicate
+inserts), a second one under the dev reloader, and a live generator during
+tests — which also forced timing-coupled tests (`time.sleep(11)`). It shared
+the global `db.session` with no rollback.
+
+## Decision
+Run the generator as its own process, `backend/worker.py`, started as a
+separate compose service. It owns its app context and DB session, samples on
+an env-configurable interval (`SAMPLE_INTERVAL_SECONDS`, default 10s), and
+rolls back per failed insert. `create_app()` no longer starts threads.
+
+## Consequences
+- Exactly one generator regardless of web concurrency; the web process is
+  stateless, so gunicorn can run multiple workers safely.
+- Tests seed `SensorData` directly and are deterministic (suite ~22s → <1s).
+- Trade-off: one more compose service to run.
+- `db.create_all()` still runs in the factory until Alembic migrations land
+  (#22); removing it is tracked there.

--- a/docs/decisions/0002-ci-gates-green-subset.md
+++ b/docs/decisions/0002-ci-gates-green-subset.md
@@ -1,0 +1,28 @@
+# ADR-0002 — CI gates only currently-green checks; strict gates phase in
+
+**Status:** Accepted (2026-06-27, PR #32, issue #19)
+
+## Context
+The target convention (CLAUDE.md §3.2) calls for backend `ruff + mypy +
+pytest`, frontend `lint + build + test`, gitleaks, and CodeQL — with "no
+allowed-to-fail stages". But on the current MVP code, three of those would
+land **red** immediately: `mypy --strict` reports 62 errors (the backend is
+unannotated), there is no ESLint config, and there was no Karma test target.
+
+## Decision
+Gate only what passes today and phase the rest in as their prerequisite
+issues land, each marked with a `NOTE` in `ci.yml`:
+- **Now:** backend `ruff` + `pytest`, frontend `npm ci` + `build`, gitleaks,
+  CodeQL (python + js-ts), Dependabot (pip/npm/actions).
+- **Frontend tests:** added in #18 (Karma).
+- **Deferred:** `mypy --strict` → after the backend is annotated (#24);
+  frontend ESLint → after the config lands (#25).
+
+We chose green-and-narrow over broad-and-red rather than using
+`continue-on-error` (which would violate "no allowed-to-fail stages").
+
+## Consequences
+- CI is trustworthy from day one: a red check means a real regression.
+- Coverage is intentionally incomplete; the gaps are explicit (in-file
+  `NOTE`s + the dev journal) so they are not mistaken for "covered".
+- Each deferred gate is a one-line addition when its issue closes.

--- a/docs/decisions/0003-frontend-nginx-same-origin-proxy.md
+++ b/docs/decisions/0003-frontend-nginx-same-origin-proxy.md
@@ -1,0 +1,27 @@
+# ADR-0003 — Production frontend served by nginx with a same-origin /api proxy
+
+**Status:** Accepted (2026-06-27, PRs #45 & #47, issues #16 & #17)
+
+## Context
+The frontend shipped `ng serve` (the dev server) as production and fetched
+from a hardcoded `http://localhost:5000`, which is cross-origin (needs CORS)
+and not portable across environments.
+
+## Decision
+- Build the app with a multi-stage Docker image and serve the static bundle
+  from a pinned `nginx:1.27-alpine`.
+- The API base URL comes from `src/environments/environment*.ts`: dev →
+  `http://localhost:5000/api/sensors`; prod → relative `/api/sensors`.
+- nginx serves the SPA (`try_files … /index.html`) and reverse-proxies
+  `/api` to `backend:5000`, so in production the browser stays on a single
+  origin and **no CORS is involved**.
+
+## Consequences
+- Production needs no CORS for the app's own calls; `CORS_ORIGINS` remains
+  for any direct cross-origin access (defense in depth).
+- nginx resolves `backend` at startup; `depends_on: condition:
+  service_healthy` guarantees the backend is up first. If the backend
+  container is later recreated with a new IP, nginx needs a reload — a
+  `resolver` + variable is the robust fix if that becomes a problem.
+- For non-compose deploys (e.g. Render, #29) the proxy target / API URL must
+  be configured for that topology.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,8 @@
+# Architecture Decision Records
+
+Short records of significant, non-obvious decisions. One file per decision,
+numbered. Format: Status / Context / Decision / Consequences.
+
+- [ADR-0001](0001-data-generator-as-worker-process.md) — Data generator runs as a dedicated worker process
+- [ADR-0002](0002-ci-gates-green-subset.md) — CI gates only currently-green checks; strict gates phase in
+- [ADR-0003](0003-frontend-nginx-same-origin-proxy.md) — Production frontend served by nginx with a same-origin /api proxy

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,0 +1,55 @@
+# Dev Journal
+
+A session-by-session log of significant work. Newest entry first.
+
+---
+
+## 2026-06-27 — P0 security + P1 correctness / CI / containers
+
+**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
+`main`, CI-gated.
+
+Drove the 360-audit refactor (epic #12) through **Phase 1 (P0 security)**
+and **Phase 2 (P1)**.
+
+### PRs merged (7)
+| PR | Summary | Closes |
+|----|---------|--------|
+| #30 | Flask debug off + gunicorn + scoped CORS; config classes (Dev/Test/Prod, default Production) | #13, #14 |
+| #34 | Sensor generator → standalone `worker.py`; deterministic seed-based route tests | #15, #20 |
+| #32 | GitHub Actions CI + CodeQL + Dependabot; `requirements-dev.txt` | #19 |
+| #33 | Karma test target + specs (app/service/home); `@angular/platform-browser-dynamic` | #18 |
+| #45 | Frontend `HttpClient` + loading/empty/error states + env-based API URL | #16 |
+| #46 | Pin/upgrade base images (py 3.12, node 22, pg 16); healthchecks + restart; DB port unpublished | #21 |
+| #47 | Multi-stage frontend Docker served by nginx (SPA + `/api` proxy) | #17 |
+
+**Issues closed:** #13, #14, #15, #16, #17, #18, #19, #20, #21.
+
+### Key decisions (see `docs/decisions/`)
+- Data generator runs as a dedicated worker process, not a factory thread — **ADR-0001**.
+- CI gates only currently-green checks; `mypy --strict` (#24) and frontend ESLint (#25) phase in later — **ADR-0002**.
+- Production frontend served by nginx with a same-origin `/api` proxy (no CORS in prod) — **ADR-0003**.
+
+### Process note (stacked PRs)
+Merging a PR with `--delete-branch` deletes the *base* branch of any child
+(stacked) PR, which GitHub then **auto-closes** — and a PR whose base branch
+is gone **cannot be reopened**. This closed #31; recovered as #34.
+**Rule:** retarget children to `main` *before* merging the parent, and delete
+branches only at the very end.
+
+### Known follow-ups / not verified this session
+- **Docker not run end-to-end:** the engine was unavailable locally, so the
+  nginx image (#17) and hardened compose (#21) were validated with
+  `docker compose config` only. A `docker compose up` smoke test is
+  recommended before the Render deploy (#29).
+- **CI deprecation warning:** `actions/checkout@v4` and `gitleaks-action@v2`
+  run on Node 20 (deprecated); the github-actions Dependabot will bump them.
+- **`backend/.env.example`** still blocked by the `.gitignore` `.env.*` rule
+  (needs a negation); deferred to the docs-reconciliation issue (#26).
+- Open Dependabot PRs (ruff, pytest) awaiting review.
+
+### Next
+Phase 3 (P2): #22 (Alembic — drops runtime `db.create_all()`, indexes
+`timestamp`), #23 (API contract/versioning), #24 (backend restructure →
+unblocks mypy-strict gate), #25 (frontend polish → unblocks ESLint gate),
+#26 (docs reconcile + ONBOARDING/PLAYBOOK), #27 (pre-commit hooks).


### PR DESCRIPTION
End-of-session documentation for the 360-audit refactor (epic #12), Phases 1–2.

- **`docs/dev-journal.md`** — 2026-06-27 entry: the 7 merged PRs, 9 closed issues, key decisions, the stacked-PR base-deletion gotcha, and known follow-ups (Docker not run end-to-end, Node-20 action deprecation, `.env.example` blocked).
- **`docs/decisions/`** — three ADRs + index:
  - ADR-0001 — data generator as a dedicated worker process
  - ADR-0002 — CI gates only currently-green checks (mypy/eslint phase in)
  - ADR-0003 — nginx same-origin `/api` proxy for the prod frontend

Partially addresses #26 (seeds the dev journal); ONBOARDING/PLAYBOOK and the full README reconcile stay in #26.

Part of #12