### PR TITLE
feat(api): harden the /api/v1/sensors contract (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,22 @@ The following services will be started:
 - [Frontend (Angular) / localhost:4200](http://localhost:4200)
 - [Backend (Flask) / localhsot:5000](http://localhost:5000)
 
-The backend offers one endpoint to retrieve sensor data:
+The backend exposes a versioned endpoint to retrieve sensor data:
 
 ```bash
-curl http://localhost:5000/api/sensors
+curl http://localhost:5000/api/v1/sensors
 ```
 
 By default, the last 100 records are returned. You can specify the number of
-records to return by passing a query parameter:
+records to return by passing a query parameter (a bounded integer, 1-100; a
+non-integer or out-of-range value returns `400`):
 
 ```bash
-curl http://localhost:5000/api/sensors?limit=1
+curl http://localhost:5000/api/v1/sensors?limit=1
 ```
+
+Operational endpoints: `GET /health` (liveness — 200 if the process is up)
+and `GET /ready` (readiness — 200 if the database is reachable, else 503).
 ## Next Steps
 - To learn more about the project, please visit [Assignment](docs/history/ASSIGNMENT.md)
 - To read about the solution, please visit [Solution](docs/history/SOLUTION.md)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,6 +2,8 @@ from flask import Flask
 from flask_cors import CORS
 from .config import get_config, split_origins
 from .routes import api, main
+from .health import health
+from .errors import register_error_handlers
 from .database import db, migrate
 from . import models  # noqa: F401  -- register models on the metadata for Alembic
 
@@ -22,6 +24,10 @@ def create_app(test_config=None):
     # Register the routes with the app
     app.register_blueprint(main)
     app.register_blueprint(api)
+    app.register_blueprint(health)
+
+    # Render errors as JSON (RFC 9457-style), not Werkzeug HTML.
+    register_error_handlers(app)
 
     # Initialize the database and migration engine. Schema comes from
     # Alembic migrations (`flask db upgrade`), never db.create_all() — the

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,4 +1,19 @@
 # encoding: utf-8
+"""Application error types and JSON error handlers.
+
+The API speaks JSON, so every error — aborts, 404s, and uncaught
+exceptions — is rendered as an RFC 9457-style problem object
+(``application/problem+json``) instead of Werkzeug's default HTML page.
+"""
+import logging
+
+from flask import jsonify
+from werkzeug.exceptions import HTTPException
+
+log = logging.getLogger(__name__)
+
+PROBLEM_CONTENT_TYPE = "application/problem+json"
+
 
 class BackendError(Exception):
     """Base class for exceptions in the backend.
@@ -33,18 +48,32 @@ class BackendError(Exception):
         return str(self)
 
 
-def demo():
-    """Demonstrates how to use the BackendError class."""
+def _problem(title, status, detail):
+    """Build a JSON problem response with the RFC 9457 media type."""
+    response = jsonify({"title": title, "status": status, "detail": detail})
+    response.status_code = status
+    response.content_type = PROBLEM_CONTENT_TYPE
+    return response
 
-    try:
-        raise BackendError(
-            message="My error message",
-            context=f"expected {int.__name__}, got {type(1.0).__name__}"
+
+def register_error_handlers(app):
+    """Register JSON error handlers on the Flask app."""
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(exc):
+        """Render aborts and HTTP errors (400/404/405/...) as JSON."""
+        return _problem(exc.name, exc.code or 500, exc.description)
+
+    @app.errorhandler(BackendError)
+    def handle_backend_error(exc):
+        """Render an unexpected domain error as a generic JSON 500.
+
+        The detail is generic so internal context is never leaked to the
+        client; the actual error is logged once here.
+        """
+        log.error("unhandled backend error: %s", exc)
+        return _problem(
+            "Internal Server Error", 500, "An internal error occurred."
         )
 
-    except BackendError as e:
-        print(e)
-
-
-if __name__ == '__main__':
-    demo()
+    return app

--- a/backend/app/health.py
+++ b/backend/app/health.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+"""Operational endpoints: shallow liveness and deep readiness.
+
+``/health`` answers "is the process up?" with no dependencies, so an
+orchestrator never restarts a healthy container just because the database
+blipped. ``/ready`` answers "can it serve traffic?" by probing the
+database, returning 503 when it cannot.
+"""
+import logging
+
+from flask import Blueprint, jsonify
+from sqlalchemy import literal, select
+
+from .database import db
+
+log = logging.getLogger(__name__)
+
+health = Blueprint('health', __name__)
+
+
+@health.route('/health')
+def liveness():
+    """Liveness: 200 if the process is alive. No dependencies, no auth."""
+    return jsonify(status='ok'), 200
+
+
+@health.route('/ready')
+def readiness():
+    """Readiness: 200 only if the database is reachable, else 503."""
+    try:
+        db.session.execute(select(literal(1)))
+    except Exception:
+        log.warning("readiness check failed: database unreachable")
+        return jsonify(status='unavailable'), 503
+
+    return jsonify(status='ready'), 200

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,15 +1,17 @@
 # encoding: utf-8
-from flask import Blueprint, jsonify, request, abort
+from flask import Blueprint, abort, jsonify, request
 from markupsafe import escape
-from .services import SensorService
 
-# Define the blueprints for the index and API
+from .services import DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, SensorService
+
+# A tiny root page plus the versioned JSON API.
 main = Blueprint('main', __name__)
-api = Blueprint('api', __name__, url_prefix='/api')
+api = Blueprint('api', __name__, url_prefix='/api/v1')
+
 
 @main.route('/')
 def home():
-    """Route to the home page.
+    """Root landing page for the backend service.
 
     Example:
         http://localhost:5000/
@@ -17,25 +19,43 @@ def home():
 
     return escape('Backend server is running!')
 
+
+def _parse_limit():
+    """Validate the ?limit= query parameter at the boundary.
+
+    Returns a bounded integer in ``[MIN_LIMIT, MAX_LIMIT]``. A missing value
+    falls back to ``DEFAULT_LIMIT``; a non-integer or out-of-range value is
+    rejected with ``400`` — never silently coerced to a default.
+    """
+    raw = request.args.get('limit')
+    if raw is None:
+        return DEFAULT_LIMIT
+
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        abort(400, description="The 'limit' parameter must be an integer")
+
+    if limit < MIN_LIMIT or limit > MAX_LIMIT:
+        abort(
+            400,
+            description=(
+                f"The 'limit' parameter must be between "
+                f"{MIN_LIMIT} and {MAX_LIMIT}"
+            ),
+        )
+
+    return limit
+
+
 @api.route('/sensors', methods=['GET'])
 def get_all_sensors():
-    """Route to get all sensor data with optional limit query parameter.
+    """Return the most recent sensor readings, newest first.
 
     Example:
-        http://localhost:5000/api/sensors?limit=10
+        http://localhost:5000/api/v1/sensors?limit=10
     """
 
-    # Get the limit query parameter
-    limit = request.args.get('limit', default=100, type=int)
-
-    # Check if the limit is too high
-    if not isinstance(limit, int) or limit < 1 or limit > 100:
-
-        # Send a 400 Bad Request response
-        abort(400, description="The value of 'limit' must be between 1 and 100")
-
-    # Fetch the sensor data from the database
+    limit = _parse_limit()
     data = SensorService.fetch_data(limit)
-
-    # Return the sensor data as JSON
     return jsonify(data)

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -1,6 +1,30 @@
-from .models import SensorData
+from datetime import timezone
+
+from sqlalchemy import select
+
 from .database import db
+from .models import SensorData
 from .sensors import AnalogSensor, DiscreteSensor
+
+# Bounds for how many readings one query may return (inclusive). The API
+# boundary validates ?limit= against these; the service default is used when
+# no limit is supplied.
+DEFAULT_LIMIT = 100
+MIN_LIMIT = 1
+MAX_LIMIT = 100
+
+
+def _iso_utc(value):
+    """Serialize a datetime as an ISO-8601 string in UTC.
+
+    Stored timestamps are naive UTC (the DB ``current_timestamp`` default);
+    they are tagged as UTC so the wire format is unambiguous (``+00:00``).
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
 
 
 class SensorService(object):
@@ -44,21 +68,26 @@ class SensorService(object):
         return reading
 
     @staticmethod
-    def fetch_data(limit=100):
-        """Get the latest sensor data from the database."""
+    def fetch_data(limit=DEFAULT_LIMIT):
+        """Get the latest sensor readings, newest first.
 
-        # Get the required amount of sensor readings
-        data = SensorData.query.order_by(
-            SensorData.timestamp.desc()
-        ).limit(limit).all()
+        Returns a list of plain dicts with the timestamp serialized as an
+        ISO-8601 UTC string.
+        """
+        statement = (
+            select(SensorData)
+            .order_by(SensorData.timestamp.desc())
+            .limit(limit)
+        )
+        rows = db.session.execute(statement).scalars().all()
 
-        # Return the data in json format
         return [
             {
-                "id": entry.id,
-                "timestamp": entry.timestamp,
-                "temperature": entry.temperature,
-                "humidity": entry.humidity,
-                "vibration": entry.vibration
-            } for entry in data
+                "id": row.id,
+                "timestamp": _iso_utc(row.timestamp),
+                "temperature": row.temperature,
+                "humidity": row.humidity,
+                "vibration": row.vibration,
+            }
+            for row in rows
         ]

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import patch
+
+from backend.app import create_app
+from backend.app.database import db
+
+
+class HealthEndpointTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        config = {
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'
+        }
+        cls.app = create_app(test_config=config)
+        cls.app_context = cls.app.app_context()
+        cls.app_context.push()
+        db.create_all()
+
+    @classmethod
+    def tearDownClass(cls):
+        db.session.remove()
+        db.drop_all()
+        cls.app_context.pop()
+
+    def setUp(self):
+        self.client = self.app.test_client()
+
+    def test_health_liveness_returns_200(self):
+        """Liveness is shallow: 200 regardless of dependencies."""
+        response = self.client.get('/health')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('ok', response.get_json()['status'])
+
+    def test_ready_returns_200_when_database_reachable(self):
+        """Readiness is 200 when the database answers."""
+        response = self.client.get('/ready')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('ready', response.get_json()['status'])
+
+    def test_ready_returns_503_when_database_unreachable(self):
+        """Readiness is 503 when the database probe raises."""
+        with patch.object(
+            db.session, 'execute', side_effect=Exception('db down')
+        ):
+            response = self.client.get('/ready')
+        self.assertEqual(503, response.status_code)
+        self.assertEqual('unavailable', response.get_json()['status'])

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,7 +1,12 @@
+import json
 import unittest
+from datetime import datetime
+
 from backend.app import create_app
 from backend.app.database import db
 from backend.app.models import SensorData
+
+SENSORS_URL = '/api/v1/sensors'
 
 
 def _reading(temperature=20.0, humidity=50.0, vibration=0):
@@ -60,13 +65,13 @@ class FlaskRouteTestCase(unittest.TestCase):
         db.session.add_all([_reading(), _reading(vibration=1)])
         db.session.commit()
 
-        response = self.client.get('/api/sensors')
+        response = self.client.get(SENSORS_URL)
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.get_json()))
 
     def test_api_sensors_empty_returns_empty_list(self):
         """With no data the route returns 200 and an empty list."""
-        response = self.client.get('/api/sensors')
+        response = self.client.get(SENSORS_URL)
         self.assertEqual(200, response.status_code)
         self.assertEqual([], response.get_json())
 
@@ -75,12 +80,40 @@ class FlaskRouteTestCase(unittest.TestCase):
         db.session.add_all([_reading() for _ in range(3)])
         db.session.commit()
 
-        response = self.client.get('/api/sensors?limit=1')
+        response = self.client.get(f'{SENSORS_URL}?limit=1')
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.get_json()))
 
     def test_api_sensors_limit_out_of_range_returns_400(self):
         """A limit outside the 1-100 bounds is rejected with 400."""
         for test_val in (-1, 0, 101):
-            response = self.client.get(f'/api/sensors?limit={test_val}')
+            response = self.client.get(f'{SENSORS_URL}?limit={test_val}')
             self.assertEqual(400, response.status_code)
+
+    def test_api_sensors_non_integer_limit_returns_400(self):
+        """A non-integer limit is rejected with 400, never coerced."""
+        for test_val in ('abc', '1.5', ''):
+            response = self.client.get(f'{SENSORS_URL}?limit={test_val}')
+            self.assertEqual(400, response.status_code)
+
+    def test_api_sensors_error_response_is_json_problem(self):
+        """Errors are JSON (RFC 9457-style), not Werkzeug HTML."""
+        response = self.client.get(f'{SENSORS_URL}?limit=abc')
+        self.assertEqual(400, response.status_code)
+        self.assertIn('application/problem+json', response.content_type)
+        body = json.loads(response.get_data(as_text=True))
+        self.assertEqual(400, body['status'])
+        self.assertIn('detail', body)
+
+    def test_api_sensors_timestamp_is_iso8601_utc(self):
+        """Timestamps serialize as ISO-8601 UTC strings, not RFC-1123."""
+        db.session.add(_reading())
+        db.session.commit()
+
+        response = self.client.get(SENSORS_URL)
+        self.assertEqual(200, response.status_code)
+        timestamp = response.get_json()[0]['timestamp']
+
+        self.assertIsInstance(timestamp, str)
+        parsed = datetime.fromisoformat(timestamp)
+        self.assertIsNotNone(parsed.tzinfo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
       interval: 10s
       retries: 5
       start_period: 15s

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -3,5 +3,5 @@
 // backend (see the nginx setup in #17 / deployment in #29).
 export const environment = {
   production: true,
-  apiUrl: '/api/sensors',
+  apiUrl: '/api/v1/sensors',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -3,5 +3,5 @@
 export const environment = {
   production: false,
   // Backend sensors endpoint. The dev backend is exposed on localhost:5000.
-  apiUrl: 'http://localhost:5000/api/sensors',
+  apiUrl: 'http://localhost:5000/api/v1/sensors',
 };


### PR DESCRIPTION
## What
Versions the API and tightens the request/response contract. Implements **#23** (P2).

## Changes
- **Versioning:** API moves to `/api/v1`; frontend env URLs + README updated. nginx already proxies `/api/`, so no nginx change.
- **Strict `limit`:** non-integer or out-of-range `?limit=` now returns `400` (named bounds constants) instead of silently coercing to the default.
- **JSON errors:** registered handlers render errors as RFC 9457-style `application/problem+json`, not Werkzeug HTML. Dropped the `print()` demo from `errors.py`; kept `BackendError` (raised by the sensor domain).
- **Timestamps:** serialized as ISO-8601 UTC; query rewritten in `select()` style.
- **Health:** new `/health` (shallow liveness) and `/ready` (deep readiness — DB probe, 503 when down); backend container healthcheck now hits `/health`.

## Verification
- Backend: `ruff check backend` clean; `pytest` **26 passed** (+3 route: non-int 400, JSON problem body, ISO timestamp; +3 health: liveness, readiness up, readiness 503).
- Frontend: `npm run build` clean; `npm test` **11 passed** (specs reference `environment.apiUrl`, so they track the new URL).

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)