### PR TITLE
chore(quality): add pre-commit hooks (ruff, gitleaks, eslint, prettier) (#27)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+# Layer-2 quality gates (see CLAUDE.md 3.2). These mirror the CI gates so
+# problems are caught before they are pushed.
+#
+#   pip install pre-commit      # once
+#   pre-commit install          # enable the git hook
+#   pre-commit run --all-files  # run against the whole repo
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  # Python lint — same as CI (`ruff check backend`).
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff-check
+        files: ^backend/
+
+  # Secret scanning — same as CI (gitleaks).
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  # Frontend lint + format — same as CI (`npm run lint` / `format:check`).
+  # Local hooks so they use the project's pinned toolchain in frontend/.
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint (frontend)
+        language: system
+        entry: bash -c 'cd frontend && npm run lint'
+        files: ^frontend/.*\.(ts|html)$
+        pass_filenames: false
+      - id: prettier
+        name: prettier (frontend)
+        language: system
+        entry: bash -c 'cd frontend && npm run format:check'
+        files: ^frontend/src/.*\.(ts|html|css|json)$
+        pass_filenames: false
+
+# NOTE: mypy is intentionally not enabled yet. The backend is not fully
+# type-annotated and db.Model / flask_migrate need typing work first — the
+# same reason CI defers `mypy --strict`. Add a mypy hook here once the
+# annotations land.

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -1,0 +1,39 @@
+# Playbook
+
+Operational commands and workflows for `sensor_app`. (This is a focused
+starter; broader workflows are expanded in #26.)
+
+## Local quality gates (pre-commit)
+
+Layer-2 gates (CLAUDE.md §3.2) mirror CI and run before each commit, so
+problems are caught locally before they are pushed.
+
+Install once per clone:
+
+```bash
+pip install pre-commit
+pre-commit install          # enable the git hook
+cd frontend && npm ci       # the eslint/prettier hooks use this toolchain
+```
+
+Run manually:
+
+```bash
+pre-commit run --all-files  # every hook across the whole repo
+pre-commit run ruff-check   # a single hook
+pre-commit autoupdate       # bump pinned hook versions
+```
+
+Hooks (see [`.pre-commit-config.yaml`](../.pre-commit-config.yaml)):
+
+| Hook | Scope | Mirrors CI |
+| --- | --- | --- |
+| `ruff-check` | `backend/` Python lint | `ruff check backend` |
+| `gitleaks` | secret scan | gitleaks job |
+| `eslint` | `frontend/` TS/HTML lint | `npm run lint` |
+| `prettier` | `frontend/src` format check | `npm run format:check` |
+| `check-yaml`, `check-merge-conflict`, `check-added-large-files` | repo | — |
+
+> **mypy is not enabled yet.** The backend is not fully type-annotated and
+> `db.Model` / `flask_migrate` need typing work first — the same reason CI
+> defers `mypy --strict`. A mypy hook joins once the annotations land.


### PR DESCRIPTION
## What
Adds Layer-2 local quality gates that mirror CI. Implements **#27** (P2).

## Changes
- **`.pre-commit-config.yaml`** with:
  - `ruff-check` on `backend/` (matches CI `ruff check backend`)
  - `gitleaks` secret scan (matches CI)
  - `eslint` + `prettier` on the frontend via local hooks (match CI `npm run lint` / `format:check`)
  - `check-yaml`, `check-merge-conflict`, `check-added-large-files`
- **`docs/PLAYBOOK.md`** — a starter playbook documenting pre-commit install/usage (the acceptance's doc requirement; #26 will expand the playbook).

## Verification
- `pre-commit run --all-files` → **all hooks pass** (revs pinned via `pre-commit autoupdate`).

## Deferred
- **mypy** is intentionally **not** enabled: the backend isn't fully type-annotated and `db.Model` / `flask_migrate` need typing work first — the same reason CI defers `mypy --strict`. Noted in the config and PLAYBOOK; it joins once annotations land. (This is the one item from the issue's literal acceptance left for a typed-backend follow-up.)

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)