### PR TITLE
docs: reconcile docs with shipped state; add ONBOARDING, expand PLAYBOOK (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ Thumbs.db
 
 # Environment variables
 .env.*
+# ...but the committed example is the documented template (CLAUDE.md 2.3).
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Introduction
 
-This project demonstrates a full-stack application simulating sensor 
-readings from an industrial plant, with a Python backend generating data, 
-storing it in a database, and exposing it via an API. A frontend application
-will display the data and allow users to interact with it.
+This project demonstrates a full-stack application simulating sensor
+readings from an industrial plant: a Python (Flask) backend generates data
+via a standalone worker, stores it in PostgreSQL, and exposes it via a
+versioned REST API; an Angular frontend displays it.
 
 ## Requirements
 
@@ -35,10 +35,11 @@ the application:
 docker compose up
 ```
 
-The following services will be started:
+The following services will be started (plus a PostgreSQL database, a
+one-shot migration step, and the data-generator worker):
 
 - [Frontend (Angular) / localhost:4200](http://localhost:4200)
-- [Backend (Flask) / localhsot:5000](http://localhost:5000)
+- [Backend (Flask) / localhost:5000](http://localhost:5000)
 
 The backend exposes a versioned endpoint to retrieve sensor data:
 
@@ -56,7 +57,11 @@ curl http://localhost:5000/api/v1/sensors?limit=1
 
 Operational endpoints: `GET /health` (liveness — 200 if the process is up)
 and `GET /ready` (readiness — 200 if the database is reachable, else 503).
+
 ## Next Steps
+
+- To set up a dev environment, see [Onboarding](docs/ONBOARDING.md)
+- For day-to-day commands, see the [Playbook](docs/PLAYBOOK.md)
 - To learn more about the project, please visit [Assignment](docs/history/ASSIGNMENT.md)
 - To read about the solution, please visit [Solution](docs/history/SOLUTION.md)
 - To contribute, please visit [Contributing](CONTRIBUTING.md)

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,94 @@
+# Onboarding
+
+Get a working `sensor_app` development environment. For day-to-day
+commands see [PLAYBOOK.md](PLAYBOOK.md); for conventions see
+[CLAUDE.md](../CLAUDE.md).
+
+## What it is
+
+Four services: an Angular SPA, a Flask REST API, a PostgreSQL database, and
+a standalone worker that simulates sensor readings. (Grafana is planned —
+see issue #7 — and not yet wired in.)
+
+```
+[ Angular SPA ] --HTTP/JSON--> [ Flask API ] --SQLAlchemy--> [ PostgreSQL ]
+   :4200 (nginx)                 :5000 (gunicorn)               :5432
+                                      ^
+                                 [ worker ] (data generator)
+```
+
+## Prerequisites
+
+- **Docker** + Docker Compose — the only requirement to run the full stack.
+- **git**.
+
+For local (non-Docker) development of a single service:
+
+- **Backend:** Python 3.12.
+- **Frontend:** Node.js 22 + npm.
+
+## Run the whole stack
+
+```bash
+git clone https://github.com/braboj/sensor-data-app
+cd sensor-data-app
+docker compose up --build
+```
+
+This starts `db` → `migrate` (applies Alembic migrations) → `backend` +
+`worker` → `frontend`. Then:
+
+- Frontend: http://localhost:4200
+- API: http://localhost:5000/api/v1/sensors
+- Liveness/readiness: http://localhost:5000/health , `/ready`
+
+## Configuration
+
+The backend reads all config from environment variables (see
+`backend/src/sensor_api/config.py`). `docker compose` sets these for you;
+for local runs, export them or create `backend/.env`.
+
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `APP_CONFIG` | Config class: `development`/`testing`/`production` | `development` |
+| `DATABASE_URL` | SQLAlchemy URL | `postgresql+psycopg2://postgres:postgres@db:5432/sensordb` |
+| `SECRET_KEY` | Flask secret (set a strong random value) | `change-me` |
+| `CORS_ORIGINS` | Comma-separated allowed origins (never `*`) | `http://localhost:4200` |
+| `SAMPLE_INTERVAL_SECONDS` | Worker sample interval | `10` |
+
+> A `backend/.env.example` template is the canonical reference; copy it to
+> `backend/.env`. Never commit `.env` itself.
+
+## Backend (local, from `backend/`)
+
+```bash
+python -m venv .venv && source .venv/Scripts/activate   # Windows Git Bash
+pip install -r requirements-dev.txt
+export PYTHONPATH=src
+flask --app sensor_api db upgrade     # apply migrations
+flask --app sensor_api run            # dev server (or: python run.py)
+python -m sensor_api.worker           # run the data generator
+pytest                                # tests
+ruff check .                          # lint
+```
+
+## Frontend (local, from `frontend/`)
+
+```bash
+npm ci
+npm start          # dev server (ng serve)
+npm run build      # production build -> dist/sensor-app
+npm test           # Karma + Jasmine (headless Chrome)
+npm run lint       # ESLint
+npm run format     # Prettier (write) / format:check
+```
+
+## Quality gates
+
+Install the local pre-commit hooks so you catch issues before pushing:
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+See [PLAYBOOK.md](PLAYBOOK.md#local-quality-gates-pre-commit) for details.

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -1,7 +1,61 @@
 # Playbook
 
-Operational commands and workflows for `sensor_app`. (This is a focused
-starter; broader workflows are expanded in #26.)
+Operational commands and workflows for `sensor_app`. New to the project?
+Start with [ONBOARDING.md](ONBOARDING.md).
+
+## Full stack (Docker)
+
+```bash
+docker compose up --build        # start db, migrate, backend, worker, frontend
+docker compose up -d             # detached
+docker compose logs -f backend   # follow a service's logs
+docker compose down              # stop
+docker compose down -v           # stop and wipe the postgres volume
+docker compose exec db psql -U postgres -d sensordb   # DB shell
+```
+
+Startup order is enforced via healthchecks: `db` → `migrate`
+(`flask db upgrade`, runs once) → `backend` + `worker` → `frontend`.
+
+## Backend (from `backend/`)
+
+```bash
+export PYTHONPATH=src                          # src layout
+flask --app sensor_api run                     # dev server (or: python run.py)
+flask --app sensor_api db upgrade              # apply migrations
+flask --app sensor_api db migrate -m "msg"     # generate a migration
+flask --app sensor_api db downgrade            # roll back one migration
+python -m sensor_api.worker                    # run the data generator
+pytest                                         # tests
+ruff check .                                   # lint
+gunicorn "sensor_api:create_app()"             # production server (Linux)
+```
+
+### Database migrations
+
+Schema changes ship a reversible Alembic migration — never
+`db.create_all()` at runtime. After changing a model:
+
+```bash
+flask --app sensor_api db migrate -m "describe the change"   # autogenerate
+# review the generated file in migrations/versions/, then:
+flask --app sensor_api db upgrade
+```
+
+Migrations are committed and applied automatically by the compose
+`migrate` service on startup.
+
+## Frontend (from `frontend/`)
+
+```bash
+npm ci               # reproducible install
+npm start            # dev server
+npm run build        # production build -> dist/sensor-app
+npm test             # Karma + Jasmine (headless Chrome)
+npm run lint         # ESLint
+npm run format       # Prettier (write)
+npm run format:check # Prettier (check only — used in CI)
+```
 
 ## Local quality gates (pre-commit)
 
@@ -37,3 +91,11 @@ Hooks (see [`.pre-commit-config.yaml`](../.pre-commit-config.yaml)):
 > **mypy is not enabled yet.** The backend is not fully type-annotated and
 > `db.Model` / `flask_migrate` need typing work first — the same reason CI
 > defers `mypy --strict`. A mypy hook joins once the annotations land.
+
+## CI
+
+GitHub Actions runs on every PR and push to `main` (see
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): backend
+(`ruff check` + `pytest`), frontend (`lint` + `format:check` + `build` +
+`test`), gitleaks, and CodeQL. `main` is protected — merge via PR on green
+CI.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -4,6 +4,53 @@ A session-by-session log of significant work. Newest entry first.
 
 ---
 
+## 2026-06-27 — P2 architecture/API/polish + repo hardening
+
+**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
+`main`, CI-gated, admin-merged (solo repo).
+
+Completed **Phase 3 (P2)** of the 360-audit refactor (epic #12) and hardened
+the repo workflow.
+
+### PRs merged (5)
+| PR | Summary | Closes |
+|----|---------|--------|
+| #49 | Alembic migrations; drop runtime `db.create_all()`; index `timestamp`; one-shot compose `migrate` service | #22 |
+| #50 | `/api/v1` contract: bounded `?limit=` (400 on bad input), RFC 9457 JSON errors, ISO-8601 UTC timestamps, `select()` style, `/health`+`/ready` | #23 |
+| #51 | Backend restructure to `src/sensor_api/` (factory/config/extensions/blueprints/services); worker → `python -m sensor_api.worker`; CI runs from `backend/` | #24 |
+| #52 | Frontend polish: number/date pipes, vibration legend, table a11y, `@if`/`@for`, ESLint + Prettier (CI-gated) | #25 |
+| #53 | Pre-commit hooks (ruff-check, gitleaks, eslint, prettier); `docs/PLAYBOOK.md` | #27 |
+
+Plus this PR (#26): reconciled `README`/`SOLUTION` with shipped reality;
+added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
+`.env.example` in `.gitignore`.
+
+**Issues closed:** #22, #23, #24, #25, #27 (and #26 by this PR).
+
+### Repo hardening (outside the epic)
+- Triaged + merged 10 Dependabot PRs (#35–#44: CI action bumps, flask-cors 5→6,
+  pytest 8→9, ruff 0.8→0.15).
+- Configured branch protection on `main` (required checks + up-to-date + PR +
+  1 approval; admins not enforced so the owner merges via override); enabled
+  repo auto-merge + delete-branch-on-merge.
+
+### Known follow-ups / not verified this session
+- **Docker still not run end-to-end** (engine unavailable all session): the
+  `migrate` service, src-layout image, and worker command were validated with
+  `docker compose config` + local SQLite, **not** a live `docker compose up`.
+  Do this smoke test before the Render deploy (#29).
+- **`backend/.env.example`** could not be written by tooling (a `.env*` write
+  guard); the `.gitignore` negation is in place, so the file just needs to be
+  dropped in. Required vars are documented in `ONBOARDING.md`.
+- **mypy** still not gated (backend un-annotated) — deferred in both CI and
+  pre-commit; needs a typed `db.Model` base + annotations.
+
+### Next
+P2 complete. Remaining: features (#7 Grafana, #8 websockets) and the Render
+deploy (#29) — run the Docker smoke test first.
+
+---
+
 ## 2026-06-27 — P0 security + P1 correctness / CI / containers
 
 **Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off

--- a/docs/history/SOLUTION.md
+++ b/docs/history/SOLUTION.md
@@ -1,4 +1,26 @@
 
+> **Status (reconciled 2026-06-27).** This is the original take-home
+> *planning* narrative and is kept for history — it does not describe the
+> current code. Where the plan and reality differ:
+>
+> | Milestone | Planned | Actual |
+> | --- | --- | --- |
+> | V0.0.1.0 | Backend REST API | ✅ Shipped (Flask + SQLAlchemy + Postgres) |
+> | V0.0.2.0 | Frontend polling the API | ✅ Shipped (Angular SPA, `HttpClient`, polling) |
+> | V0.0.3.0 | Grafana integration | ⛔ **Not shipped** — planned, issue #7 |
+> | V0.0.4.0 | WebSockets for real-time | ⛔ **Not shipped** — planned, issue #8 (currently polling) |
+> | V0.0.5.0 | Optional features | ◐ Partial |
+> | V0.0.6.0 | CI/CD pipeline | ✅ Shipped (GitHub Actions + CodeQL + Dependabot) |
+>
+> Since the MVP, the 360-audit refactor (epic #12) brought the code to a
+> production shape: Alembic migrations, a versioned `/api/v1` contract with
+> JSON errors and `/health`+`/ready`, a `src/sensor_api/` factory/blueprints
+> layout, ESLint/Prettier, and pre-commit hooks. The `flask-socketio`
+> dependency is a leftover from the original websocket exploration (the
+> `scripts/` folder) and is not used by the running app. For current state
+> see [ONBOARDING.md](../ONBOARDING.md), [PLAYBOOK.md](../PLAYBOOK.md), and
+> [dev-journal.md](../dev-journal.md).
+
 ## Overview
 
 ### Requirements


### PR DESCRIPTION
## What
Reconciles the docs with what actually shipped and adds the companion docs the templates expect. Implements **#26** (P2 — the last open P2 item).

## Changes
- **README:** present-tense overview, fixed `localhsot` typo, noted the db/migrate/worker services, added Onboarding + Playbook links.
- **SOLUTION.md:** status banner mapping the original take-home milestones to reality — **Grafana (#7) and WebSockets (#8) are not shipped**, CI is — while preserving the historical narrative. Flags `flask-socketio` as an unused leftover.
- **docs/ONBOARDING.md** (new): prerequisites, run-the-stack, per-service local dev, env-var reference, quality gates.
- **docs/PLAYBOOK.md:** expanded from the pre-commit starter into a full command reference (docker, backend, migrations, frontend, pre-commit, CI).
- **docs/dev-journal.md:** entry for the P2 session (#22–#27 + repo hardening).
- **.gitignore:** un-ignore `.env.example` (negate the `.env.*` rule).

## Note / follow-up
`backend/.env.example` is **not** included — the local tooling blocks writing `.env*` files. The `.gitignore` negation is in place and every required var is documented in ONBOARDING.md, so the file just needs to be dropped in (content is in the env-var table). Flagging rather than silently skipping.

## Verification
- `pre-commit run --all-files` passes (gitleaks accepts the `postgres:postgres` dev string, consistent with compose).

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)