### PR TITLE
fix(frontend): set page title to "Sensor Dashboard"

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Default</title>
+    <title>Sensor Dashboard</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
The document `<title>` was still the Angular scaffold default (`Default`) — visible in the browser tab and as the bookmark/share label. Set it to the app name, `Sensor Dashboard`.

Surfaced during the Docker full-stack smoke test.

One-line change in `frontend/src/index.html`.

Verified: `npm run lint` + `format:check` clean; 11 Karma tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)