### PR TITLE
docs: rule against decorative --- rules + strip existing ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,6 @@ chain (`stack-flask` + frontend layer + platform):
 - Platform & process: `platform/github.md`, `base/workflow/scope.md`,
   `base/workflow/360.md`
 
----
-
 ## 1. Project
 
 ### 1.1 Overview
@@ -143,8 +141,6 @@ npm run build                          # production build -> dist/sensor-app
 npm test                               # Karma + Jasmine (needs a test target)
 npx eslint .                           # lint
 ```
-
----
 
 ## 2. Code conventions
 
@@ -274,7 +270,12 @@ npx eslint .                           # lint
   not expose the DB port to the host in production. Secrets via env, not
   literals.
 
----
+### 2.10 Documentation
+
+- Write docs (README, `docs/*.md`, ADRs, PR/issue bodies) with heading
+  hierarchy and blank-line spacing for structure; do **not** use `---`
+  horizontal rules as decorative section separators. Reserve `---` for where
+  it is structural (YAML/TOML frontmatter, fenced code).
 
 ## 3. Quality
 
@@ -313,15 +314,11 @@ npx eslint .                           # lint
   (`contents: read`). Full framework: `base/security/security.md`,
   `base/security/devsecops.md`.
 
----
-
 ## 4. Identity
 
 Minimal. The frontend is a functional dashboard; follow `frontend/ux.md`
 for layout/accessibility. No formal brand system — keep styling
 consistent and the table readable.
-
----
 
 ## 5. Review process
 
@@ -352,8 +349,6 @@ Confirm CI is green before merge.
   has a reversible migration.
 - Run a full 360 (`base/workflow/360.md`) after a milestone or before a
   release; store at `docs/audits/YYYY-MM-DD-360.md`.
-
----
 
 ## 6. Session protocol
 

--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -55,8 +55,6 @@ all above ──► #26 docs reconcile + companions
 stable base ──► #7 Grafana, #8 real-time, #3 (features)
 ```
 
----
-
 ## Phase 1 — Security (P0) · issues #13, #14
 
 Smallest possible diffs on the current code for immediate risk
@@ -133,8 +131,6 @@ Only after the base is solid:
 - **#8** Real-time delivery (WebSocket/SSE) replacing/augmenting polling.
 - **#3** Round out the Angular dashboard (chart selection per the
   original assignment).
-
----
 
 ## Verification per phase
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -2,6 +2,52 @@
 
 A session-by-session log of significant work. Newest entry first.
 
+## 2026-06-28 — Docker smoke test + Render deploy (#29) + small fixes
+
+**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
+`main`, CI-gated, owner-merged.
+
+First live `docker compose up` of the refactored stack, then implemented the
+Render free-tier deployment (#29) plus two small fixes. All three PRs are open
+and green, awaiting owner approval/merge (none merged yet).
+
+### Docker smoke test (the pre-#29 gate from the last entry)
+Full stack came up healthy in order (db → migrate → backend → worker →
+frontend); `/health`·`/ready`·`/api/v1/sensors` 200, bad `?limit` 400, 404
+JSON; worker inserted every 10s; nginx proxied `/api`; gunicorn (no dev
+server). Surfaced one nit: the page `<title>` was still `Default`.
+
+### PRs opened (3, all green, pending merge)
+| PR | Summary | Closes |
+|----|---------|--------|
+| #55 | Render free-tier Blueprint (`render.yaml`: managed PG + Docker backend + static frontend) + `DEPLOY.md` + ADR-0004; `postgres://` URL normalization; `run_generator()` + gunicorn `post_worker_init` in-process generator; `render-start.sh`; build-time `API_URL` injection | #29 |
+| #56 | Page `<title>` → "Sensor Dashboard" | — |
+| #57 | CLAUDE.md §2.10 doc-style rule (no decorative `---`) + strip existing rules from CLAUDE/dev-journal/REFACTOR-PLAN | — |
+
+### Key decision
+- Free-tier in-process generator (scoped exception to ADR-0001), started in the
+  gunicorn **worker** not master — **ADR-0004**. The master variant
+  (`when_ready`) deadlocked request workers via the fork-after-thread hazard;
+  caught by a full Render-path Docker simulation, not just YAML review.
+
+### Verification
+Backend ruff + 30 pytest; frontend lint + format + build + 11 Karma tests; a
+live `docker compose up`; and a Render-path Docker sim (migrate→gunicorn,
+`$PORT` bind, `postgres://` normalization, in-process generator, API contract
+200/400/404). All 6 CI checks green on each PR.
+
+### Known follow-ups / pending
+- **Merges pending owner approval** for #55/#56/#57; #29 auto-closes on #55.
+- **Connect the repo in Render** (New + → Blueprint) after #55 merges; then fix
+  `CORS_ORIGINS`/`API_URL` if Render suffixes the service hostnames (DEPLOY.md).
+- **`backend/.env.example`** still not dropped in (tooling `.env*` guard).
+- **mypy** still not gated.
+- Historical docs (360 audit, ASSIGNMENT) intentionally keep their `---`.
+
+### Next
+Merge the three PRs; connect Render. Then features — #7 Grafana, #8 websockets;
+docs #10/#11.
+
 ## 2026-06-27 — P2 architecture/API/polish + repo hardening
 
 **Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -2,8 +2,6 @@
 
 A session-by-session log of significant work. Newest entry first.
 
----
-
 ## 2026-06-27 — P2 architecture/API/polish + repo hardening
 
 **Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
@@ -48,8 +46,6 @@ added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
 ### Next
 P2 complete. Remaining: features (#7 Grafana, #8 websockets) and the Render
 deploy (#29) — run the Docker smoke test first.
-
----
 
 ## 2026-06-27 — P0 security + P1 correctness / CI / containers
 


### PR DESCRIPTION
Establishes a repo-wide documentation-style rule and makes the convention/living docs follow it.

## Rule (CLAUDE.md §2.10 Documentation)
> Write docs (README, `docs/*.md`, ADRs, PR/issue bodies) with heading hierarchy and blank-line spacing for structure; do **not** use `---` horizontal rules as decorative section separators. Reserve `---` for where it is structural (YAML/TOML frontmatter, fenced code).

## Strip existing decorative rules
- `CLAUDE.md` — 6 removed (the file now follows its own rule).
- `docs/dev-journal.md` — 2 removed.
- `docs/REFACTOR-PLAN.md` — 2 removed.

All removals were section dividers immediately before a `##` heading, so structure is unchanged (headings + spacing remain).

## Intentionally left untouched
Dated, point-in-time historical records — reformatting a record of what was produced at a moment is inappropriate:
- `docs/audits/2026-06-26-360.md` (12 rules)
- `docs/history/ASSIGNMENT.md` (1 rule, verbatim original assignment)

README.md already had none.

Docs-only; no code or CI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)