### PR TITLE
docs(journal): order oldest-first + make lint-clean (templates ADR-015)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD013": { "line_length": 80, "code_blocks": false, "tables": false },
+  "MD022": false,
+  "MD024": { "siblings_only": true },
+  "MD031": false,
+  "MD032": false,
+  "MD040": false,
+  "MD060": false
+}

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -12,6 +12,7 @@ Drove the 360-audit refactor (epic #12) through **Phase 1 (P0 security)**
 and **Phase 2 (P1)**.
 
 ### PRs merged (7)
+
 | PR | Summary | Closes |
 |----|---------|--------|
 | #30 | Flask debug off + gunicorn + scoped CORS; config classes (Dev/Test/Prod, default Production) | #13, #14 |
@@ -25,11 +26,16 @@ and **Phase 2 (P1)**.
 **Issues closed:** #13, #14, #15, #16, #17, #18, #19, #20, #21.
 
 ### Key decisions (see `docs/decisions/`)
-- Data generator runs as a dedicated worker process, not a factory thread — **ADR-0001**.
-- CI gates only currently-green checks; `mypy --strict` (#24) and frontend ESLint (#25) phase in later — **ADR-0002**.
-- Production frontend served by nginx with a same-origin `/api` proxy (no CORS in prod) — **ADR-0003**.
+
+- Data generator runs as a dedicated worker process, not a factory thread
+  — **ADR-0001**.
+- CI gates only currently-green checks; `mypy --strict` (#24) and frontend
+  ESLint (#25) phase in later — **ADR-0002**.
+- Production frontend served by nginx with a same-origin `/api` proxy (no
+  CORS in prod) — **ADR-0003**.
 
 ### Process note (stacked PRs)
+
 Merging a PR with `--delete-branch` deletes the *base* branch of any child
 (stacked) PR, which GitHub then **auto-closes** — and a PR whose base branch
 is gone **cannot be reopened**. This closed #31; recovered as #34.
@@ -37,6 +43,7 @@ is gone **cannot be reopened**. This closed #31; recovered as #34.
 branches only at the very end.
 
 ### Known follow-ups / not verified this session
+
 - **Docker not run end-to-end:** the engine was unavailable locally, so the
   nginx image (#17) and hardened compose (#21) were validated with
   `docker compose config` only. A `docker compose up` smoke test is
@@ -48,10 +55,11 @@ branches only at the very end.
 - Open Dependabot PRs (ruff, pytest) awaiting review.
 
 ### Next
+
 Phase 3 (P2): #22 (Alembic — drops runtime `db.create_all()`, indexes
 `timestamp`), #23 (API contract/versioning), #24 (backend restructure →
-unblocks mypy-strict gate), #25 (frontend polish → unblocks ESLint gate),
-#26 (docs reconcile + ONBOARDING/PLAYBOOK), #27 (pre-commit hooks).
+unblocks mypy-strict gate), #25 (frontend polish → unblocks ESLint
+gate), #26 (docs reconcile + ONBOARDING/PLAYBOOK), #27 (pre-commit hooks).
 
 ## 2026-06-27 — P2 architecture/API/polish + repo hardening
 
@@ -62,6 +70,7 @@ Completed **Phase 3 (P2)** of the 360-audit refactor (epic #12) and hardened
 the repo workflow.
 
 ### PRs merged (5)
+
 | PR | Summary | Closes |
 |----|---------|--------|
 | #49 | Alembic migrations; drop runtime `db.create_all()`; index `timestamp`; one-shot compose `migrate` service | #22 |
@@ -77,13 +86,15 @@ added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
 **Issues closed:** #22, #23, #24, #25, #27 (and #26 by this PR).
 
 ### Repo hardening (outside the epic)
-- Triaged + merged 10 Dependabot PRs (#35–#44: CI action bumps, flask-cors 5→6,
-  pytest 8→9, ruff 0.8→0.15).
+
+- Triaged + merged 10 Dependabot PRs (#35–#44: CI action bumps, flask-cors
+  5→6, pytest 8→9, ruff 0.8→0.15).
 - Configured branch protection on `main` (required checks + up-to-date + PR +
   1 approval; admins not enforced so the owner merges via override); enabled
   repo auto-merge + delete-branch-on-merge.
 
-### Known follow-ups / not verified this session
+### Known follow-ups / not verified (P2 session)
+
 - **Docker still not run end-to-end** (engine unavailable all session): the
   `migrate` service, src-layout image, and worker command were validated with
   `docker compose config` + local SQLite, **not** a live `docker compose up`.
@@ -95,6 +106,7 @@ added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
   pre-commit; needs a typed `db.Model` base + annotations.
 
 ### Next
+
 P2 complete. Remaining: features (#7 Grafana, #8 websockets) and the Render
 deploy (#29) — run the Docker smoke test first.
 
@@ -103,17 +115,20 @@ deploy (#29) — run the Docker smoke test first.
 **Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
 `main`, CI-gated, owner-merged.
 
-First live `docker compose up` of the refactored stack, then implemented the
-Render free-tier deployment (#29) plus two small fixes. All three PRs (#55,
-#56, #57) merged to `main` (admin override squash); #29 auto-closed on #55.
+First live `docker compose up` of the refactored stack, then implemented
+the Render free-tier deployment (#29) plus two small fixes. All three PRs
+(#55, #56, #57) merged to `main` (admin override squash); #29 auto-closed
+on #55.
 
 ### Docker smoke test (the pre-#29 gate from the last entry)
+
 Full stack came up healthy in order (db → migrate → backend → worker →
 frontend); `/health`·`/ready`·`/api/v1/sensors` 200, bad `?limit` 400, 404
 JSON; worker inserted every 10s; nginx proxied `/api`; gunicorn (no dev
 server). Surfaced one nit: the page `<title>` was still `Default`.
 
 ### PRs merged (3)
+
 | PR | Summary | Closes |
 |----|---------|--------|
 | #55 | Render free-tier Blueprint (`render.yaml`: managed PG + Docker backend + static frontend) + `DEPLOY.md` + ADR-0004; `postgres://` URL normalization; `run_generator()` + gunicorn `post_worker_init` in-process generator; `render-start.sh`; build-time `API_URL` injection | #29 |
@@ -121,18 +136,21 @@ server). Surfaced one nit: the page `<title>` was still `Default`.
 | #57 | CLAUDE.md §2.10 doc-style rule (no decorative `---`) + strip existing rules from CLAUDE/dev-journal/REFACTOR-PLAN | — |
 
 ### Key decision
-- Free-tier in-process generator (scoped exception to ADR-0001), started in the
-  gunicorn **worker** not master — **ADR-0004**. The master variant
+
+- Free-tier in-process generator (scoped exception to ADR-0001), started in
+  the gunicorn **worker** not master — **ADR-0004**. The master variant
   (`when_ready`) deadlocked request workers via the fork-after-thread hazard;
   caught by a full Render-path Docker simulation, not just YAML review.
 
 ### Verification
+
 Backend ruff + 30 pytest; frontend lint + format + build + 11 Karma tests; a
 live `docker compose up`; and a Render-path Docker sim (migrate→gunicorn,
 `$PORT` bind, `postgres://` normalization, in-process generator, API contract
 200/400/404). All 6 CI checks green on each PR before merge.
 
 ### Known follow-ups / pending
+
 - **Connect the repo in Render** (New + → Blueprint) now that #55 is merged;
   then fix `CORS_ORIGINS`/`API_URL` if Render suffixes the service hostnames
   (DEPLOY.md).
@@ -141,4 +159,5 @@ live `docker compose up`; and a Render-path Docker sim (migrate→gunicorn,
 - Historical docs (360 audit, ASSIGNMENT) intentionally keep their `---`.
 
 ### Next
+
 Connect Render. Then features — #7 Grafana, #8 websockets; docs #10/#11.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,97 +1,7 @@
 # Dev Journal
 
-A session-by-session log of significant work. Newest entry first.
-
-## 2026-06-28 — Docker smoke test + Render deploy (#29) + small fixes
-
-**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
-`main`, CI-gated, owner-merged.
-
-First live `docker compose up` of the refactored stack, then implemented the
-Render free-tier deployment (#29) plus two small fixes. All three PRs are open
-and green, awaiting owner approval/merge (none merged yet).
-
-### Docker smoke test (the pre-#29 gate from the last entry)
-Full stack came up healthy in order (db → migrate → backend → worker →
-frontend); `/health`·`/ready`·`/api/v1/sensors` 200, bad `?limit` 400, 404
-JSON; worker inserted every 10s; nginx proxied `/api`; gunicorn (no dev
-server). Surfaced one nit: the page `<title>` was still `Default`.
-
-### PRs opened (3, all green, pending merge)
-| PR | Summary | Closes |
-|----|---------|--------|
-| #55 | Render free-tier Blueprint (`render.yaml`: managed PG + Docker backend + static frontend) + `DEPLOY.md` + ADR-0004; `postgres://` URL normalization; `run_generator()` + gunicorn `post_worker_init` in-process generator; `render-start.sh`; build-time `API_URL` injection | #29 |
-| #56 | Page `<title>` → "Sensor Dashboard" | — |
-| #57 | CLAUDE.md §2.10 doc-style rule (no decorative `---`) + strip existing rules from CLAUDE/dev-journal/REFACTOR-PLAN | — |
-
-### Key decision
-- Free-tier in-process generator (scoped exception to ADR-0001), started in the
-  gunicorn **worker** not master — **ADR-0004**. The master variant
-  (`when_ready`) deadlocked request workers via the fork-after-thread hazard;
-  caught by a full Render-path Docker simulation, not just YAML review.
-
-### Verification
-Backend ruff + 30 pytest; frontend lint + format + build + 11 Karma tests; a
-live `docker compose up`; and a Render-path Docker sim (migrate→gunicorn,
-`$PORT` bind, `postgres://` normalization, in-process generator, API contract
-200/400/404). All 6 CI checks green on each PR.
-
-### Known follow-ups / pending
-- **Merges pending owner approval** for #55/#56/#57; #29 auto-closes on #55.
-- **Connect the repo in Render** (New + → Blueprint) after #55 merges; then fix
-  `CORS_ORIGINS`/`API_URL` if Render suffixes the service hostnames (DEPLOY.md).
-- **`backend/.env.example`** still not dropped in (tooling `.env*` guard).
-- **mypy** still not gated.
-- Historical docs (360 audit, ASSIGNMENT) intentionally keep their `---`.
-
-### Next
-Merge the three PRs; connect Render. Then features — #7 Grafana, #8 websockets;
-docs #10/#11.
-
-## 2026-06-27 — P2 architecture/API/polish + repo hardening
-
-**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
-`main`, CI-gated, admin-merged (solo repo).
-
-Completed **Phase 3 (P2)** of the 360-audit refactor (epic #12) and hardened
-the repo workflow.
-
-### PRs merged (5)
-| PR | Summary | Closes |
-|----|---------|--------|
-| #49 | Alembic migrations; drop runtime `db.create_all()`; index `timestamp`; one-shot compose `migrate` service | #22 |
-| #50 | `/api/v1` contract: bounded `?limit=` (400 on bad input), RFC 9457 JSON errors, ISO-8601 UTC timestamps, `select()` style, `/health`+`/ready` | #23 |
-| #51 | Backend restructure to `src/sensor_api/` (factory/config/extensions/blueprints/services); worker → `python -m sensor_api.worker`; CI runs from `backend/` | #24 |
-| #52 | Frontend polish: number/date pipes, vibration legend, table a11y, `@if`/`@for`, ESLint + Prettier (CI-gated) | #25 |
-| #53 | Pre-commit hooks (ruff-check, gitleaks, eslint, prettier); `docs/PLAYBOOK.md` | #27 |
-
-Plus this PR (#26): reconciled `README`/`SOLUTION` with shipped reality;
-added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
-`.env.example` in `.gitignore`.
-
-**Issues closed:** #22, #23, #24, #25, #27 (and #26 by this PR).
-
-### Repo hardening (outside the epic)
-- Triaged + merged 10 Dependabot PRs (#35–#44: CI action bumps, flask-cors 5→6,
-  pytest 8→9, ruff 0.8→0.15).
-- Configured branch protection on `main` (required checks + up-to-date + PR +
-  1 approval; admins not enforced so the owner merges via override); enabled
-  repo auto-merge + delete-branch-on-merge.
-
-### Known follow-ups / not verified this session
-- **Docker still not run end-to-end** (engine unavailable all session): the
-  `migrate` service, src-layout image, and worker command were validated with
-  `docker compose config` + local SQLite, **not** a live `docker compose up`.
-  Do this smoke test before the Render deploy (#29).
-- **`backend/.env.example`** could not be written by tooling (a `.env*` write
-  guard); the `.gitignore` negation is in place, so the file just needs to be
-  dropped in. Required vars are documented in `ONBOARDING.md`.
-- **mypy** still not gated (backend un-annotated) — deferred in both CI and
-  pre-commit; needs a typed `db.Model` base + annotations.
-
-### Next
-P2 complete. Remaining: features (#7 Grafana, #8 websockets) and the Render
-deploy (#29) — run the Docker smoke test first.
+A session-by-session log of significant work, in chronological order —
+oldest first, newest entry at the bottom (per solid-ai-templates ADR-015).
 
 ## 2026-06-27 — P0 security + P1 correctness / CI / containers
 
@@ -142,3 +52,93 @@ Phase 3 (P2): #22 (Alembic — drops runtime `db.create_all()`, indexes
 `timestamp`), #23 (API contract/versioning), #24 (backend restructure →
 unblocks mypy-strict gate), #25 (frontend polish → unblocks ESLint gate),
 #26 (docs reconcile + ONBOARDING/PLAYBOOK), #27 (pre-commit hooks).
+
+## 2026-06-27 — P2 architecture/API/polish + repo hardening
+
+**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
+`main`, CI-gated, admin-merged (solo repo).
+
+Completed **Phase 3 (P2)** of the 360-audit refactor (epic #12) and hardened
+the repo workflow.
+
+### PRs merged (5)
+| PR | Summary | Closes |
+|----|---------|--------|
+| #49 | Alembic migrations; drop runtime `db.create_all()`; index `timestamp`; one-shot compose `migrate` service | #22 |
+| #50 | `/api/v1` contract: bounded `?limit=` (400 on bad input), RFC 9457 JSON errors, ISO-8601 UTC timestamps, `select()` style, `/health`+`/ready` | #23 |
+| #51 | Backend restructure to `src/sensor_api/` (factory/config/extensions/blueprints/services); worker → `python -m sensor_api.worker`; CI runs from `backend/` | #24 |
+| #52 | Frontend polish: number/date pipes, vibration legend, table a11y, `@if`/`@for`, ESLint + Prettier (CI-gated) | #25 |
+| #53 | Pre-commit hooks (ruff-check, gitleaks, eslint, prettier); `docs/PLAYBOOK.md` | #27 |
+
+Plus this PR (#26): reconciled `README`/`SOLUTION` with shipped reality;
+added `docs/ONBOARDING.md`; expanded `docs/PLAYBOOK.md`; un-ignored
+`.env.example` in `.gitignore`.
+
+**Issues closed:** #22, #23, #24, #25, #27 (and #26 by this PR).
+
+### Repo hardening (outside the epic)
+- Triaged + merged 10 Dependabot PRs (#35–#44: CI action bumps, flask-cors 5→6,
+  pytest 8→9, ruff 0.8→0.15).
+- Configured branch protection on `main` (required checks + up-to-date + PR +
+  1 approval; admins not enforced so the owner merges via override); enabled
+  repo auto-merge + delete-branch-on-merge.
+
+### Known follow-ups / not verified this session
+- **Docker still not run end-to-end** (engine unavailable all session): the
+  `migrate` service, src-layout image, and worker command were validated with
+  `docker compose config` + local SQLite, **not** a live `docker compose up`.
+  Do this smoke test before the Render deploy (#29).
+- **`backend/.env.example`** could not be written by tooling (a `.env*` write
+  guard); the `.gitignore` negation is in place, so the file just needs to be
+  dropped in. Required vars are documented in `ONBOARDING.md`.
+- **mypy** still not gated (backend un-annotated) — deferred in both CI and
+  pre-commit; needs a typed `db.Model` base + annotations.
+
+### Next
+P2 complete. Remaining: features (#7 Grafana, #8 websockets) and the Render
+deploy (#29) — run the Docker smoke test first.
+
+## 2026-06-28 — Docker smoke test + Render deploy (#29) + small fixes
+
+**Tool:** Claude Code (Opus 4.8) · **Branch model:** one concern per PR off
+`main`, CI-gated, owner-merged.
+
+First live `docker compose up` of the refactored stack, then implemented the
+Render free-tier deployment (#29) plus two small fixes. All three PRs (#55,
+#56, #57) merged to `main` (admin override squash); #29 auto-closed on #55.
+
+### Docker smoke test (the pre-#29 gate from the last entry)
+Full stack came up healthy in order (db → migrate → backend → worker →
+frontend); `/health`·`/ready`·`/api/v1/sensors` 200, bad `?limit` 400, 404
+JSON; worker inserted every 10s; nginx proxied `/api`; gunicorn (no dev
+server). Surfaced one nit: the page `<title>` was still `Default`.
+
+### PRs merged (3)
+| PR | Summary | Closes |
+|----|---------|--------|
+| #55 | Render free-tier Blueprint (`render.yaml`: managed PG + Docker backend + static frontend) + `DEPLOY.md` + ADR-0004; `postgres://` URL normalization; `run_generator()` + gunicorn `post_worker_init` in-process generator; `render-start.sh`; build-time `API_URL` injection | #29 |
+| #56 | Page `<title>` → "Sensor Dashboard" | — |
+| #57 | CLAUDE.md §2.10 doc-style rule (no decorative `---`) + strip existing rules from CLAUDE/dev-journal/REFACTOR-PLAN | — |
+
+### Key decision
+- Free-tier in-process generator (scoped exception to ADR-0001), started in the
+  gunicorn **worker** not master — **ADR-0004**. The master variant
+  (`when_ready`) deadlocked request workers via the fork-after-thread hazard;
+  caught by a full Render-path Docker simulation, not just YAML review.
+
+### Verification
+Backend ruff + 30 pytest; frontend lint + format + build + 11 Karma tests; a
+live `docker compose up`; and a Render-path Docker sim (migrate→gunicorn,
+`$PORT` bind, `postgres://` normalization, in-process generator, API contract
+200/400/404). All 6 CI checks green on each PR before merge.
+
+### Known follow-ups / pending
+- **Connect the repo in Render** (New + → Blueprint) now that #55 is merged;
+  then fix `CORS_ORIGINS`/`API_URL` if Render suffixes the service hostnames
+  (DEPLOY.md).
+- **`backend/.env.example`** still not dropped in (tooling `.env*` guard).
+- **mypy** still not gated.
+- Historical docs (360 audit, ASSIGNMENT) intentionally keep their `---`.
+
+### Next
+Connect Render. Then features — #7 Grafana, #8 websockets; docs #10/#11.


### PR DESCRIPTION
## What

Two doc-hygiene fixes to `docs/dev-journal.md`, plus a repo markdownlint config.

1. **Ordering** — reorder session entries to **oldest-first (newest at the bottom)** and fix the intro line that said "Newest entry first." Per solid-ai-templates `base/core/docs.md` + **ADR-015 (Dev-journal entries are ordered oldest-first)**.
2. **Lint-clean** — the journal had ~50 markdownlint warnings. Adopt the solid-ai-templates `.markdownlint.json` at repo root and reflow the journal so it passes.

## markdownlint config

Mirrors the templates' config (`MD013` 80-col with code/tables exempt; `MD022`/`MD031`/`MD032`/`MD040`/`MD060` off), with one addition: `MD024: { siblings_only: true }` — so the per-entry section headings (`### PRs merged`, `### Next`, `### Known follow-ups`) can repeat across dated entries without tripping no-duplicate-heading. The templates' own journal avoids this with bold-label fields; ours keeps the table/sub-heading style, so siblings_only is the right local escape hatch.

## Journal content fixes (no information changed)

- Blank line before each PR table (MD058)
- Wrapped the ADR/Dependabot bullets to ≤80 (MD013)
- Rewrapped two lines so they no longer start with `#NN` (MD018)
- Refreshed the 2026-06-28 entry: #55/#56/#57 now show as **merged** (#29 auto-closed)

## Verification

`npx markdownlint-cli2 docs/dev-journal.md` → **0 errors** (reads the new config). Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)