### PR TITLE
docs(refactor-plan): strip stray heredoc terminator from file tail

### DIFF
--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -146,5 +146,3 @@ Only after the base is solid:
 Phases 1→6 in order. Within a phase, one PR per issue. Phases 2 and 3
 can run in parallel (different stacks) once Phase 1 lands; Phase 4's #19
 waits on the test issues (#20, #18).
-EOF
-echo "written docs/REFACTOR-PLAN.md"


### PR DESCRIPTION
## What

`docs/REFACTOR-PLAN.md` ended with two stray lines that leaked from a heredoc into the document body — a heredoc terminator and an `echo` command. This removes them and restores a clean trailing newline. Pure content cleanup; no semantic change to the plan.

## Why

Not valid Markdown content; reads as a leftover shell artifact at the bottom of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
