### PR TITLE
feat(grafana): provision Postgres datasource + dashboard as code (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ one-shot migration step, and the data-generator worker):
 
 - [Frontend (Angular) / localhost:4200](http://localhost:4200)
 - [Backend (Flask) / localhost:5000](http://localhost:5000)
+- [Grafana / localhost:3000](http://localhost:3000)
+
+Grafana ships with a PostgreSQL datasource and a "Sensor Readings" dashboard
+provisioned as code (`deploy/grafana/provisioning/`). Log in with `admin` /
+`admin` (override via `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`).
 
 The backend exposes a versioned endpoint to retrieve sensor data:
 

--- a/deploy/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,17 @@
+# Dashboard provider, provisioned as code (CLAUDE.md §2.8). Grafana loads
+# every *.json dashboard in `options.path` (this directory) and ignores
+# this YAML, so the provider config and the dashboards can live together.
+apiVersion: 1
+
+providers:
+  - name: Sensor dashboards
+    orgId: 1
+    type: file
+    disableDeletion: true
+    # Re-read the files periodically so committed changes show up on restart.
+    updateIntervalSeconds: 30
+    # Managed by provisioning — do not allow edits through the UI.
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/dashboards/sensor-readings.json
+++ b/deploy/grafana/provisioning/dashboards/sensor-readings.json
@@ -1,0 +1,125 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Live plant sensor readings from the sensor_data table (timestamps are UTC).",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "postgres", "uid": "sensordb-pg" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Temperature (°C)" },
+            "properties": [{ "id": "unit", "value": "celsius" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Humidity (%)" },
+            "properties": [{ "id": "unit", "value": "humidity" }]
+          }
+        ]
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["last", "min", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "Temperature & Humidity",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "sensordb-pg" },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS \"time\", temperature AS \"Temperature (°C)\", humidity AS \"Humidity (%)\" FROM sensor_data WHERE $__timeFilter(timestamp) ORDER BY timestamp",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "sensordb-pg" },
+      "description": "Vibration is a coded value: 0 = no vibration detected, 1 = vibration detected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 9 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["last"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "title": "Vibration (0 = none, 1 = detected)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "sensordb-pg" },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS \"time\", vibration AS \"Vibration\" FROM sensor_data WHERE $__timeFilter(timestamp) ORDER BY timestamp",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["sensor", "plant"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Sensor Readings",
+  "uid": "sensor-readings",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/datasources/datasource.yaml
+++ b/deploy/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,23 @@
+# Grafana datasource, provisioned as code (CLAUDE.md §2.8).
+# Credentials are interpolated from environment variables passed to the
+# grafana service in docker-compose.yml — no secrets are committed here.
+apiVersion: 1
+
+datasources:
+  - name: PostgreSQL
+    uid: sensordb-pg
+    type: postgres
+    access: proxy
+    url: db:5432
+    user: ${POSTGRES_USER}
+    # `database` is the canonical top-level field for SQL datasources.
+    database: ${POSTGRES_DB}
+    isDefault: true
+    # Managed by provisioning — do not allow edits through the UI.
+    editable: false
+    secureJsonData:
+      password: ${POSTGRES_PASSWORD}
+    jsonData:
+      sslmode: disable
+      postgresVersion: 1600
+      timescaledb: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,38 @@ services:
       start_period: 10s
       timeout: 5s
 
+  # Grafana visualizes the sensor_data table. Datasource and dashboards are
+  # provisioned as code from deploy/grafana/provisioning (CLAUDE.md §2.8) —
+  # nothing is configured through the UI. DB credentials are passed via env
+  # and interpolated in the datasource YAML; no secrets are committed.
+  grafana:
+    image: grafana/grafana:11.4.0
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      # Consumed by deploy/grafana/provisioning/datasources/datasource.yaml.
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=sensordb
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/api/health || exit 1"]
+      interval: 15s
+      retries: 5
+      start_period: 20s
+      timeout: 5s
+
   # One-shot schema migration. Runs `flask db upgrade` once the DB is
   # healthy, then exits; backend and worker wait for it to complete
   # successfully (schema comes from Alembic, never db.create_all()). Reuses
@@ -100,4 +132,6 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+  grafana_data:
     driver: local

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -6,15 +6,16 @@ commands see [PLAYBOOK.md](PLAYBOOK.md); for conventions see
 
 ## What it is
 
-Four services: an Angular SPA, a Flask REST API, a PostgreSQL database, and
-a standalone worker that simulates sensor readings. (Grafana is planned —
-see issue #7 — and not yet wired in.)
+Five services: an Angular SPA, a Flask REST API, a PostgreSQL database, a
+standalone worker that simulates sensor readings, and Grafana (datasource +
+dashboard provisioned as code from `deploy/grafana/provisioning/`).
 
 ```
 [ Angular SPA ] --HTTP/JSON--> [ Flask API ] --SQLAlchemy--> [ PostgreSQL ]
    :4200 (nginx)                 :5000 (gunicorn)               :5432
-                                      ^
-                                 [ worker ] (data generator)
+                                      ^                            ^
+                                 [ worker ] (data generator)      |
+                                                            [ Grafana ] :3000
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## What

Wires **Grafana** into the stack as the fifth service, fully provisioned as code per CLAUDE.md §2.8. This is the last open item from the refactor plan's feature backlog (Phase 6).

- **`docker-compose.yml`** — pinned `grafana/grafana:11.4.0` service with a healthcheck, `restart: unless-stopped`, and a `grafana_data` volume. Depends on `db` (healthy) + `migrate` (completed). DB credentials passed via env (no secrets committed); admin login overridable via `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` (default `admin`/`admin` for local).
- **`deploy/grafana/provisioning/datasources/datasource.yaml`** — PostgreSQL datasource (`uid: sensordb-pg`), credentials interpolated from env.
- **`deploy/grafana/provisioning/dashboards/`** — file provider + a "Sensor Readings" dashboard: temperature/humidity time series and a vibration (0/1) panel over the `sensor_data` table, timezone UTC.
- **README / ONBOARDING** — document the Grafana service, port `:3000`, and login.

## Verification

Brought the stack up locally (`db` + `migrate` + `worker` + `grafana`) and confirmed via Grafana's API:

- `GET /api/health` → `{"database":"ok","version":"11.4.0"}`
- Datasource provisioned: `PostgreSQL` (`uid: sensordb-pg`, isDefault).
- `GET /api/datasources/uid/sensordb-pg/health` → `{"message":"Database Connection OK","status":"OK"}`
- Dashboard provisioned: `Sensor Readings` (`uid: sensor-readings`).
- The panel SQL projection returns seeded worker rows against the real schema.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
