### PR TITLE
chore(config): add committed backend/.env.example template (closes #60)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,44 @@
+# Backend configuration — copy to `.env` and fill in real values.
+# `.env` is git-ignored; this committed template documents every variable the
+# backend reads. Values here are safe placeholders, NOT real secrets.
+
+# --- Required ---
+
+# Which config class to load: development | testing | production.
+# Defaults to production (fail-safe: no debugger/dev server). See config.py.
+APP_CONFIG=development
+
+# SQLAlchemy database URL. The compose/psycopg2 form is shown; a managed
+# `postgres://` URL is normalised to `postgresql://` automatically.
+# Falls back to a local sqlite file if unset.
+DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/sensordb
+
+# Flask secret key (sessions, signing). No default — set a long random value.
+SECRET_KEY=change-me-to-a-long-random-string
+
+# Comma-separated list of allowed frontend origins for CORS (never "*").
+CORS_ORIGINS=http://localhost:4200
+
+# --- Optional ---
+
+# Data-generator sample interval, in seconds (worker). Default: 10.
+SAMPLE_INTERVAL_SECONDS=10
+
+# Override the test database URL (TestingConfig). Default: in-memory sqlite.
+# TEST_DATABASE_URL=sqlite:///:memory:
+
+# --- gunicorn (production entrypoint; see gunicorn.conf.py) ---
+
+# Port to bind. Platform hosts (Render) inject $PORT. Default: 5000.
+# PORT=5000
+
+# Number of web workers. Default: 1 (free-tier friendly).
+# WEB_CONCURRENCY=1
+
+# gunicorn worker class. Default: gevent, so the SSE stream
+# (/api/v1/sensors/stream) does not tie up the worker. Set "sync" to disable.
+# GUNICORN_WORKER_CLASS=gevent
+
+# Run the data generator in-process instead of as a separate worker service.
+# Only for single-worker free tiers (see ADR-0004). Default: off.
+# RUN_INPROCESS_GENERATOR=1


### PR DESCRIPTION
## What

Adds `backend/.env.example` — the config template that `docs/ONBOARDING.md` already names as the canonical reference but which didn't exist yet.

- Documents every variable the backend reads: `APP_CONFIG`, `DATABASE_URL`, `SECRET_KEY`, `CORS_ORIGINS`, plus optional worker (`SAMPLE_INTERVAL_SECONDS`, `TEST_DATABASE_URL`) and gunicorn (`PORT`, `WEB_CONCURRENCY`, `GUNICORN_WORKER_CLASS`, `RUN_INPROCESS_GENERATOR`) vars.
- **Safe placeholders only** — no real secrets. The `DATABASE_URL` placeholder matches the one already committed in `docker-compose.yml`.
- `.env` stays git-ignored; `.gitignore` already negates `!.env.example`, so the template is committable.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)