### PR TITLE
chore(quality): gate mypy --strict on the backend (closes #61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
       - name: Lint (ruff)
         run: ruff check .
 
+      - name: Type check (mypy --strict)
+        run: mypy src
+
       - name: Test (pytest)
         run: pytest
-      # NOTE: `mypy --strict` is not gated yet — the backend is not fully
-      # type-annotated. It joins this job once the annotations land.
 
   frontend:
     name: Frontend (build)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,12 @@ repos:
         files: ^frontend/src/.*\.(ts|html|css|json)$
         pass_filenames: false
 
-# NOTE: mypy is intentionally not enabled yet. The backend is not fully
-# type-annotated and db.Model / flask_migrate need typing work first — the
-# same reason CI defers `mypy --strict`. Add a mypy hook here once the
-# annotations land.
+      # Strict type check — same as CI (`mypy src` from backend/). Local hook
+      # so it uses the backend's installed toolchain (pip install
+      # -r backend/requirements-dev.txt).
+      - id: mypy
+        name: mypy (backend, strict)
+        language: system
+        entry: bash -c 'cd backend && mypy src'
+        files: ^backend/.*\.py$
+        pass_filenames: false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,3 +5,17 @@
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+
+# Strict static typing for the application package. Run `mypy src` from
+# backend/ (CI and the pre-commit hook do exactly that).
+[tool.mypy]
+python_version = "3.12"
+mypy_path = "src"
+files = ["src"]
+strict = true
+
+# These libraries ship no type information; ignore the missing-import error
+# rather than weaken strictness for our own code.
+[[tool.mypy.overrides]]
+module = ["flask_migrate", "flask_cors"]
+ignore_missing_imports = true

--- a/backend/src/sensor_api/__init__.py
+++ b/backend/src/sensor_api/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from flask import Flask
 from flask_cors import CORS
 
@@ -8,7 +10,7 @@ from .errors import register_error_handlers
 from .extensions import db, migrate
 
 
-def create_app(test_config=None):
+def create_app(test_config: dict[str, Any] | None = None) -> Flask:
     """Application factory — wiring only (config, extensions, blueprints).
 
     No global app, no threads, no db.create_all(): the schema comes from

--- a/backend/src/sensor_api/blueprints/health/routes.py
+++ b/backend/src/sensor_api/blueprints/health/routes.py
@@ -9,6 +9,7 @@ database, returning 503 when it cannot.
 import logging
 
 from flask import Blueprint, jsonify
+from flask.typing import ResponseReturnValue
 from markupsafe import escape
 from sqlalchemy import literal, select
 
@@ -20,19 +21,19 @@ health = Blueprint('health', __name__)
 
 
 @health.route('/')
-def home():
+def home() -> ResponseReturnValue:
     """Root landing page for the backend service."""
     return escape('Backend server is running!')
 
 
 @health.route('/health')
-def liveness():
+def liveness() -> ResponseReturnValue:
     """Liveness: 200 if the process is alive. No dependencies, no auth."""
     return jsonify(status='ok'), 200
 
 
 @health.route('/ready')
-def readiness():
+def readiness() -> ResponseReturnValue:
     """Readiness: 200 only if the database is reachable, else 503."""
     try:
         db.session.execute(select(literal(1)))

--- a/backend/src/sensor_api/blueprints/sensors/models.py
+++ b/backend/src/sensor_api/blueprints/sensors/models.py
@@ -1,8 +1,13 @@
 # encoding: utf-8
-from ...extensions import db
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...extensions import Base
 
 
-class SensorData(db.Model):
+class SensorData(Base):
     """Basic sensor data model with temperature, humidity, and vibration.
 
     The model is deliberately kept simple for demonstration purposes. In a real
@@ -10,14 +15,17 @@ class SensorData(db.Model):
     sensor ID, location, and metadata.
     """
 
-    id = db.Column(db.Integer, primary_key=True)
-    # Indexed: every read orders by timestamp DESC (see SensorService).
-    timestamp = db.Column(
-        db.DateTime, default=db.func.current_timestamp(), index=True
-    )
-    temperature = db.Column(db.Float, nullable=False)
-    humidity = db.Column(db.Float, nullable=False)
-    vibration = db.Column(db.Integer, nullable=False)
+    __tablename__ = "sensor_data"
 
-    def __repr__(self):
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # Indexed: every read orders by timestamp DESC (see SensorService). Nullable
+    # to match the committed migration; the DB default always populates it.
+    timestamp: Mapped[datetime | None] = mapped_column(
+        default=func.current_timestamp(), index=True
+    )
+    temperature: Mapped[float] = mapped_column(nullable=False)
+    humidity: Mapped[float] = mapped_column(nullable=False)
+    vibration: Mapped[int] = mapped_column(nullable=False)
+
+    def __repr__(self) -> str:
         return f"<SensorData id={self.id} timestamp={self.timestamp}>"

--- a/backend/src/sensor_api/blueprints/sensors/routes.py
+++ b/backend/src/sensor_api/blueprints/sensors/routes.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 from flask import Blueprint, jsonify, request
+from flask.typing import ResponseReturnValue
 
 from .schemas import parse_limit, serialize_reading
 from .services import SensorService
@@ -8,7 +9,7 @@ api = Blueprint('sensors', __name__, url_prefix='/api/v1')
 
 
 @api.route('/sensors', methods=['GET'])
-def get_all_sensors():
+def get_all_sensors() -> ResponseReturnValue:
     """Return the most recent sensor readings, newest first.
 
     Example:

--- a/backend/src/sensor_api/blueprints/sensors/schemas.py
+++ b/backend/src/sensor_api/blueprints/sensors/schemas.py
@@ -4,9 +4,12 @@
 Keeps the route thin: the boundary parses/validates the query and shapes
 the response here, the service owns the query.
 """
-from datetime import timezone
+from datetime import datetime, timezone
+from typing import Any
 
 from flask import abort
+
+from .models import SensorData
 
 # Bounds for the ?limit= query parameter (inclusive). A missing value uses
 # the default; a non-integer or out-of-range value is rejected with 400.
@@ -15,7 +18,7 @@ MIN_LIMIT = 1
 MAX_LIMIT = 100
 
 
-def parse_limit(raw):
+def parse_limit(raw: str | None) -> int:
     """Validate the ?limit= query value into a bounded integer.
 
     Returns ``DEFAULT_LIMIT`` when absent; aborts with ``400`` on a
@@ -41,7 +44,7 @@ def parse_limit(raw):
     return limit
 
 
-def _iso_utc(value):
+def _iso_utc(value: datetime | None) -> str | None:
     """Serialize a datetime as an ISO-8601 string in UTC.
 
     Stored timestamps are naive UTC (the DB ``current_timestamp`` default);
@@ -54,7 +57,7 @@ def _iso_utc(value):
     return value.astimezone(timezone.utc).isoformat()
 
 
-def serialize_reading(row):
+def serialize_reading(row: SensorData) -> dict[str, Any]:
     """Shape one ``SensorData`` row into a JSON-ready dict."""
     return {
         "id": row.id,

--- a/backend/src/sensor_api/blueprints/sensors/services.py
+++ b/backend/src/sensor_api/blueprints/sensors/services.py
@@ -1,4 +1,6 @@
 # encoding: utf-8
+from collections.abc import Sequence
+
 from sqlalchemy import select
 
 from ...extensions import db
@@ -6,12 +8,15 @@ from ...sensors import AnalogSensor, DiscreteSensor
 from .models import SensorData
 from .schemas import DEFAULT_LIMIT
 
+# The simulated field sensors, in the order readings are recorded.
+Sensors = tuple[AnalogSensor, AnalogSensor, DiscreteSensor]
+
 
 class SensorService(object):
     """Service class for handling sensor data."""
 
     @staticmethod
-    def build_sensors():
+    def build_sensors() -> Sensors:
         """Construct the simulated field sensors.
 
         Built once by the worker and reused across samples so each sensor
@@ -24,7 +29,7 @@ class SensorService(object):
         )
 
     @staticmethod
-    def record_reading(sensors):
+    def record_reading(sensors: Sensors) -> SensorData:
         """Sample the sensors and persist a single reading.
 
         Requires an active app context. On failure the session is rolled
@@ -48,7 +53,7 @@ class SensorService(object):
         return reading
 
     @staticmethod
-    def fetch_data(limit=DEFAULT_LIMIT):
+    def fetch_data(limit: int = DEFAULT_LIMIT) -> Sequence[SensorData]:
         """Return the latest sensor readings (ORM rows), newest first.
 
         Serialization is the boundary's job (see schemas.serialize_reading).

--- a/backend/src/sensor_api/config.py
+++ b/backend/src/sensor_api/config.py
@@ -79,5 +79,5 @@ DEFAULT_CONFIG = "production"
 
 def get_config(name: str | None = None) -> type[BaseConfig]:
     """Resolve a config class by name, defaulting to the safe production."""
-    selected = name or os.getenv("APP_CONFIG", DEFAULT_CONFIG)
+    selected = name or os.getenv("APP_CONFIG") or DEFAULT_CONFIG
     return CONFIG_MAP.get(selected, ProductionConfig)

--- a/backend/src/sensor_api/errors.py
+++ b/backend/src/sensor_api/errors.py
@@ -7,7 +7,8 @@ exceptions — is rendered as an RFC 9457-style problem object
 """
 import logging
 
-from flask import jsonify
+from flask import Flask, Response, jsonify
+from flask.typing import ResponseReturnValue
 from werkzeug.exceptions import HTTPException
 
 log = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class BackendError(Exception):
         )
     """
 
-    def __init__(self, message, context=None):
+    def __init__(self, message: str, context: str | None = None) -> None:
         """Initializes the BackendError instance.
 
         Args:
@@ -40,15 +41,15 @@ class BackendError(Exception):
         self.context = context
         super().__init__(self.message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         context = f"({self.context})" if self.context else ""
         return f"{self.__class__.__name__}: {self.message} {context}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
 
-def _problem(title, status, detail):
+def _problem(title: str, status: int, detail: str | None) -> Response:
     """Build a JSON problem response with the RFC 9457 media type."""
     response = jsonify({"title": title, "status": status, "detail": detail})
     response.status_code = status
@@ -56,16 +57,16 @@ def _problem(title, status, detail):
     return response
 
 
-def register_error_handlers(app):
+def register_error_handlers(app: Flask) -> Flask:
     """Register JSON error handlers on the Flask app."""
 
     @app.errorhandler(HTTPException)
-    def handle_http_exception(exc):
+    def handle_http_exception(exc: HTTPException) -> ResponseReturnValue:
         """Render aborts and HTTP errors (400/404/405/...) as JSON."""
         return _problem(exc.name, exc.code or 500, exc.description)
 
     @app.errorhandler(BackendError)
-    def handle_backend_error(exc):
+    def handle_backend_error(exc: BackendError) -> ResponseReturnValue:
         """Render an unexpected domain error as a generic JSON 500.
 
         The detail is generic so internal context is never leaked to the

--- a/backend/src/sensor_api/extensions.py
+++ b/backend/src/sensor_api/extensions.py
@@ -6,6 +6,17 @@ via ``init_app``.
 """
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase
 
-db = SQLAlchemy()
+
+class Base(DeclarativeBase):
+    """Typed declarative base.
+
+    Giving SQLAlchemy an explicit ``DeclarativeBase`` lets models use
+    ``Mapped[...]`` annotations, so instance attributes carry real types
+    (e.g. ``SensorData.id`` is ``int``, not ``Any``) under ``mypy --strict``.
+    """
+
+
+db = SQLAlchemy(model_class=Base)
 migrate = Migrate()

--- a/backend/src/sensor_api/sensors.py
+++ b/backend/src/sensor_api/sensors.py
@@ -1,5 +1,6 @@
 import random
 from abc import ABC, abstractmethod
+from typing import Self
 
 from .errors import BackendError
 
@@ -9,82 +10,66 @@ class _SensorAbc(ABC):
 
     @property
     @abstractmethod
-    def tag(self):
-        """The tag name of the sensor.
-
-        Returns:
-            str: The tag name of the sensor.
-        """
+    def tag(self) -> str:
+        """The tag name of the sensor."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def low_limit(self):
-        """The low limit of the sensor.
-
-        Returns:
-            int | float: The low limit of the sensor.
-        """
+    def low_limit(self) -> float:
+        """The low limit of the sensor."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def high_limit(self):
-        """The high limit of the sensor.
-
-        Returns:
-            int | float: The high limit of the sensor.
-        """
+    def high_limit(self) -> float:
+        """The high limit of the sensor."""
         raise NotImplementedError
 
     @abstractmethod
-    def read(self):
-        """Read the sensor data.
-
-        Returns:
-            int | float: The sensor data.
-        """
+    def read(self) -> float:
+        """Read the sensor data."""
         raise NotImplementedError
 
     @abstractmethod
-    def validate(self):
+    def validate(self) -> Self:
         """Validate the sensor instance."""
         raise NotImplementedError
 
 
-class _SensorBase(object):
+class _SensorBase:
     """Base class for all sensors types."""
 
-    def __init__(self, tag, low_limit, high_limit):
+    def __init__(self, tag: str, low_limit: float, high_limit: float) -> None:
         """Initialize the sensor with a tag name."""
 
         self._tag = tag
-        self._low_limit = low_limit
-        self._high_limit = high_limit
-        self._last_value = None
+        self._low_limit: float = low_limit
+        self._high_limit: float = high_limit
+        self._last_value: float | None = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.tag}: {self._last_value}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
     @property
-    def tag(self):
+    def tag(self) -> str:
         """The tag name of the sensor."""
         return self._tag
 
     @property
-    def low_limit(self):
+    def low_limit(self) -> float:
         """The low limit of the sensor."""
         return self._low_limit
 
     @property
-    def high_limit(self):
+    def high_limit(self) -> float:
         """The high limit of the sensor."""
         return self._high_limit
 
-    def validate(self):
+    def validate(self) -> Self:
         """Validate the discrete sensor instance."""
 
         # Validate the sensor instance
@@ -132,7 +117,9 @@ class DiscreteSensor(_SensorBase, _SensorAbc):
         sensor2.read()
     """
 
-    def __init__(self, tag, low_limit=0, high_limit=1):
+    def __init__(
+        self, tag: str, low_limit: int = 0, high_limit: int = 1
+    ) -> None:
 
         # Call the base class constructor
         super(DiscreteSensor, self).__init__(tag, low_limit, high_limit)
@@ -144,13 +131,16 @@ class DiscreteSensor(_SensorBase, _SensorAbc):
         self._low_limit = int(self.low_limit)
         self._high_limit = int(self.high_limit)
 
-    def read(self):
+    def read(self) -> int:
         """Read the discrete sensor data."""
 
-        self._last_value = random.randint(self.low_limit, self.high_limit)
-        return self._last_value
+        # Limits are stored as ints in __init__; cast satisfies randint's
+        # integer-argument signature (the property type is the numeric float).
+        value = random.randint(int(self.low_limit), int(self.high_limit))
+        self._last_value = value
+        return value
 
-    def validate(self):
+    def validate(self) -> Self:
         """Validate the discrete sensor instance."""
 
         # Validate the basic requirements for the sensor
@@ -188,7 +178,9 @@ class AnalogSensor(_SensorBase, _SensorAbc):
         sensor2.read()
     """
 
-    def __init__(self, tag, low_limit=0.0, high_limit=100.0):
+    def __init__(
+        self, tag: str, low_limit: float = 0.0, high_limit: float = 100.0
+    ) -> None:
 
         # Call the base class constructor
         super(AnalogSensor, self).__init__(tag, low_limit, high_limit)
@@ -200,13 +192,14 @@ class AnalogSensor(_SensorBase, _SensorAbc):
         self._low_limit = float(self.low_limit)
         self._high_limit = float(self.high_limit)
 
-    def read(self):
+    def read(self) -> float:
         """Read the analog sensor data."""
 
-        self._last_value = random.uniform(self.low_limit, self.high_limit)
-        return self._last_value
+        value = random.uniform(self.low_limit, self.high_limit)
+        self._last_value = value
+        return value
 
-    def validate(self):
+    def validate(self) -> Self:
 
         # Validate the basic requirements for the sensor
         super().validate()

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -28,6 +28,7 @@ flask --app sensor_api db downgrade            # roll back one migration
 python -m sensor_api.worker                    # run the data generator
 pytest                                         # tests
 ruff check .                                   # lint
+mypy src                                       # strict type check (CI-gated)
 gunicorn "sensor_api:create_app()"             # production server (Linux)
 ```
 
@@ -83,22 +84,19 @@ Hooks (see [`.pre-commit-config.yaml`](../.pre-commit-config.yaml)):
 | Hook | Scope | Mirrors CI |
 | --- | --- | --- |
 | `ruff-check` | `backend/` Python lint | `ruff check backend` |
+| `mypy` | `backend/` strict type check | `mypy src` |
 | `gitleaks` | secret scan | gitleaks job |
 | `eslint` | `frontend/` TS/HTML lint | `npm run lint` |
 | `prettier` | `frontend/src` format check | `npm run format:check` |
 | `check-yaml`, `check-merge-conflict`, `check-added-large-files` | repo | — |
 
-> **mypy is not enabled yet.** The backend is not fully type-annotated and
-> `db.Model` / `flask_migrate` need typing work first — the same reason CI
-> defers `mypy --strict`. A mypy hook joins once the annotations land.
-
 ## CI
 
 GitHub Actions runs on every PR and push to `main` (see
 [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): backend
-(`ruff check` + `pytest`), frontend (`lint` + `format:check` + `build` +
-`test`), gitleaks, and CodeQL. `main` is protected — merge via PR on green
-CI.
+(`ruff check` + `mypy src` + `pytest`), frontend
+(`lint` + `format:check` + `build` + `test`), gitleaks, and CodeQL. `main` is
+protected — merge via PR on green CI.
 
 ## Deploy (Render free tier)
 

--- a/docs/decisions/0006-gate-mypy-strict.md
+++ b/docs/decisions/0006-gate-mypy-strict.md
@@ -1,0 +1,34 @@
+# ADR-0006 — Gate `mypy --strict` on the backend
+
+**Status:** Accepted (2026-06-30, issue #61). Supersedes the mypy carve-out in
+[ADR-0002](0002-ci-gates-green-subset.md).
+
+## Context
+ADR-0002 shipped CI as a deliberately green subset and deferred `mypy --strict`
+because the backend was unannotated and `db.Model` / `flask_migrate` typed as
+`Any`. CLAUDE.md §2.2/§3.2 target a strict-clean backend, so the carve-out was
+always meant to be temporary.
+
+## Decision
+- Annotate every backend signature and gate `mypy --strict` (`mypy src` from
+  `backend/`, config in `pyproject.toml`) in CI and as a pre-commit hook.
+- **Typed model base.** Define an explicit `class Base(DeclarativeBase)` in
+  `extensions.py` and construct `SQLAlchemy(model_class=Base)`. Models subclass
+  `Base` **directly** (not `db.Model`, which flask-sqlalchemy still types as
+  `Any`) and declare columns with `Mapped[...]` / `mapped_column`, so instance
+  attributes carry real types (`SensorData.id` is `int`). An explicit
+  `__tablename__` preserves the table name without relying on the base's
+  auto-naming. This is schema-compatible — no migration change.
+- **Untyped third-party libs.** `flask_migrate` and `flask_cors` ship no types;
+  silence their missing-import error with a scoped `[[tool.mypy.overrides]]`
+  rather than weakening strictness for our own code.
+
+## Consequences
+- New backend code must be annotated or CI fails — the type boundary is now
+  enforced, not aspirational.
+- The CI job retains the name **"Backend (ruff + pytest)"** even though it now
+  also runs mypy, because that string is a required status check in branch
+  protection; renaming it would block merges until the protection rule is
+  updated. Rename + update protection together as a follow-up if desired.
+- The `Mapped` model style is the SQLAlchemy 2.0 idiom; future models should
+  follow it.


### PR DESCRIPTION
## What

Annotates the backend and **gates `mypy --strict`** in CI and pre-commit — closing the temporary carve-out from ADR-0002. CLAUDE.md §2.2/§3.2 always targeted a strict-clean backend.

### Typed model base
- Explicit `class Base(DeclarativeBase)` + `SQLAlchemy(model_class=Base)` in `extensions.py`.
- `SensorData` subclasses `Base` **directly** (flask-sqlalchemy still types `db.Model` as `Any`) with `Mapped[...]` / `mapped_column` columns and an explicit `__tablename__`, so instance attributes carry real types (`SensorData.id` → `int`). **Schema-compatible — no migration change** (verified: pytest's `create_all` builds the same DDL).

### Annotations
Every signature across `config`, `errors`, `sensors`, `schemas`, `services`, `routes`, `health`, and the app factory. Flask handlers use `flask.typing.ResponseReturnValue`; the sensor fluent validators use `typing.Self`.

### Config + gate
- `pyproject.toml`: `[tool.mypy] strict = true` (`files = ["src"]`); scoped `[[tool.mypy.overrides]]` to ignore the missing types for `flask_migrate` / `flask_cors` (no weakening of our own code).
- CI: a **mypy step** in the backend job (`mypy src`).
- pre-commit: a `mypy (backend, strict)` hook mirroring CI.

## Verification

Clean container (mirrors CI): `mypy src` → **Success, 14 files**; `ruff check .` clean; `pytest` → **30 passed**.

## Notes for the reviewer

- **CI job name unchanged** ("Backend (ruff + pytest)") even though it now also runs mypy — that string is a **required status check** in branch protection, so renaming it would block merges until the rule is updated. Suggest renaming + updating protection as a separate step.
- **Cross-PR interaction with #66 (SSE):** the SSE branch adds backend code (`events.py`, `fetch_since`, the stream route) that this gate will check once both land. I'm pushing a follow-up commit to **#66** annotating that code to the same standard, so mypy stays green in either merge order.
- ADR-0006 records the decision (supersedes ADR-0002's mypy carve-out).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
