### PR TITLE
docs: update repo references to braboj/demo-sensor-app after rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Angular frontend displays it; PostgreSQL persists it; Grafana visualizes
 it.
 
 - Owner: Branimir Georgiev (Imbra.io)
-- Repo: github.com/braboj/sensor-data-app
+- Repo: github.com/braboj/demo-sensor-app
 - Deployment: Docker Compose (local); container images per service
 - Model: hybrid
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Clone the repository using the following command (replace `<project-name>`
 with the name of your project):
 
 ```bash
-git clone https://github.com/braboj/sensor-data-app <project-name>
+git clone https://github.com/braboj/demo-sensor-app <project-name>
 ```
 
 For a specific branch, use the following command:
 
 ```bash
-git clone -b <branch-name> https://github.com/braboj/sensor-data-app <project-name>
+git clone -b <branch-name> https://github.com/braboj/demo-sensor-app <project-name>
 ```
 
 Navigate to the project folder and run the following command to start 
@@ -79,4 +79,4 @@ and `GET /ready` (readiness — 200 if the database is reachable, else 503).
 - To learn more about the project, please visit [Assignment](docs/history/ASSIGNMENT.md)
 - To read about the solution, please visit [Solution](docs/history/SOLUTION.md)
 - To contribute, please visit [Contributing](CONTRIBUTING.md)
-- To leave feedback, please visit [Discussions](https://github.com/braboj/sensor-data-app/discussions)
+- To leave feedback, please visit [Discussions](https://github.com/braboj/demo-sensor-app/discussions)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -26,7 +26,7 @@ is scoped to the static site's URL.
 
 ## One-time setup
 
-1. Push this repo to GitHub (already done: `braboj/sensor-data-app`).
+1. Push this repo to GitHub (already done: `braboj/demo-sensor-app`).
 2. In the Render dashboard: **New +** → **Blueprint**.
 3. Connect the repository and select the branch. Render reads `render.yaml`
    from the repo root and shows the three resources above.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -31,8 +31,8 @@ For local (non-Docker) development of a single service:
 ## Run the whole stack
 
 ```bash
-git clone https://github.com/braboj/sensor-data-app
-cd sensor-data-app
+git clone https://github.com/braboj/demo-sensor-app
+cd demo-sensor-app
 docker compose up --build
 ```
 


### PR DESCRIPTION
## What

The GitHub repo was renamed **`braboj/sensor-data-app` → `braboj/demo-sensor-app`**. Old URLs still redirect, but the docs should name the canonical repo so clone/connect steps are correct.

- **CLAUDE.md** — `Repo:` line
- **README.md** — clone URLs (×2) + Discussions link
- **docs/DEPLOY.md** — Render Blueprint connect target (the reason this matters for go-live)
- **docs/ONBOARDING.md** — clone URL + `cd`

Left **`docs/audits/2026-06-26-360.md`** unchanged: it is a dated historical snapshot that records the old name (and flags the naming inconsistency as a finding) — editing it would falsify the record.

## Why now

Prep for **#62** (connect the Blueprint in Render + verify the live deploy): the connect step must point at the correct repo. Does not close #62 — the live deploy is a separate owner action in the Render dashboard.

Refs #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)