### PR TITLE
fix(frontend): remove the Grafana link from the readings table

### DIFF
--- a/frontend/src/app/home/home.component.css
+++ b/frontend/src/app/home/home.component.css
@@ -33,18 +33,3 @@ th {
   font-style: normal;
   font-weight: 600;
 }
-
-.grafana-link {
-  margin: 8px 0 0;
-}
-
-.grafana-link a {
-  color: #1f6feb;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.grafana-link a:hover,
-.grafana-link a:focus {
-  text-decoration: underline;
-}

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -3,7 +3,6 @@ import { Observable, Subject, of, throwError } from 'rxjs';
 import { HomeComponent } from './home.component';
 import { SensorService } from '../sensors.service';
 import { SensorData } from '../sensordata';
-import { environment } from '../../environments/environment';
 
 const rows: SensorData[] = [
   {
@@ -47,17 +46,6 @@ describe('HomeComponent', () => {
   it('should create', () => {
     const fixture = createFixture(() => of(rows));
     expect(fixture.componentInstance).toBeTruthy();
-  });
-
-  it('links to the configured Grafana dashboard', () => {
-    const fixture = createFixture(() => of(rows));
-    fixture.detectChanges();
-
-    const link = (fixture.nativeElement as HTMLElement).querySelector(
-      '.grafana-link a',
-    );
-    expect(link).toBeTruthy();
-    expect(link?.getAttribute('href')).toBe(environment.grafanaUrl);
   });
 
   it('renders one table row per reading on success', () => {

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { Subscription, catchError, of } from 'rxjs';
 import { SensorService } from '../sensors.service';
 import { SensorData } from '../sensordata';
-import { environment } from '../../environments/environment';
 
 // Cap the live table so an always-open stream cannot grow it without bound.
 const MAX_ROWS = 100;
@@ -23,14 +22,6 @@ const MAX_ROWS = 100;
   template: `
     <section class="results">
       <h2>Latest Sensor Data</h2>
-
-      @if (grafanaUrl) {
-        <p class="grafana-link">
-          <a [href]="grafanaUrl" target="_blank" rel="noopener noreferrer">
-            View charts in Grafana ↗
-          </a>
-        </p>
-      }
 
       @if (live) {
         <p class="status status-live" role="status">
@@ -102,10 +93,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   // SSE connection failed.
   live = false;
   liveError = false;
-
-  // Optional link to the Grafana dashboard (charting lives there); empty when
-  // Grafana is not part of the deploy (see environments/environment*.ts).
-  readonly grafanaUrl = environment.grafanaUrl;
 
   // Inject the sensor service
   private readonly sensorService = inject(SensorService);


### PR DESCRIPTION
Cosmetic cleanup: the in-table "View charts in Grafana" link is redundant now that the **Charts** nav tab embeds the dashboard. Removes the markup, the unused `grafanaUrl` field + `environment` import, the `.grafana-link` styles, and its spec.

Verified locally: eslint + prettier + build + 22 karma specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)