### PR TITLE
docs(readme): polish for the demo — live link, badges, features (closes #11)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2026 Branimir Georgiev
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml)
-[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 # Sensor Dashboard
 
@@ -191,4 +191,4 @@ static frontend, and Grafana. The live demo above runs from this blueprint. See
 
 ## License
 
-Released into the public domain under [The Unlicense](LICENSE).
+Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,82 +1,124 @@
-# Introduction
+[![CI](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml)
 
-This project demonstrates a full-stack application simulating sensor
-readings from an industrial plant: a Python (Flask) backend generates data
-via a standalone worker, stores it in PostgreSQL, and exposes it via a
-versioned REST API; an Angular frontend displays it.
+# Sensor Dashboard
+
+*A multi-service demo that simulates industrial-plant sensor readings —
+generated, stored, streamed live, and charted.*
+
+A Python (Flask) backend generates sensor data via a standalone worker, stores
+it in PostgreSQL, and exposes it through a versioned REST API; an Angular
+frontend shows a live table and embeds Grafana for charting.
+
+**🌐 Live demo:** <https://sensor-app-frontend.onrender.com> — the **Live Table**
+tab streams new readings in real time, and the **Charts** tab embeds the Grafana
+dashboard. It runs on Render's free tier, so the first request after a while may
+cold-start for ~30–60s.
+
+## Features
+
+- **Live table** — Angular SPA (standalone components) with explicit loading,
+  empty, and error states; new readings arrive over **Server-Sent Events**, not
+  polling.
+- **Charts** — the embedded Grafana "Sensor Readings" dashboard with a metric
+  selector (temperature / humidity / vibration) and a moving-average trend,
+  provisioned as code.
+- **Versioned REST API** — `/api/v1/sensors` with a bounded `?limit=`, ISO-8601
+  UTC timestamps, and RFC 9457 JSON errors; plus `/health` and `/ready`.
+- **Separate generator** — the simulator runs as its own worker process, not a
+  thread inside the web app.
+- **One command** — `docker compose up` starts the backend, frontend,
+  PostgreSQL, Grafana, and the worker; the schema comes from Alembic migrations.
+- **Deployable** — a free-tier [Render blueprint](render.yaml) runs the whole
+  stack (see [Deploy](docs/DEPLOY.md)).
 
 ## Requirements
 
-To install and run the application, the following software must be installed
-on your system:
+To run the application, install:
 
 - [Docker](https://docs.docker.com/engine/install/)
 - [git](https://git-scm.com/downloads)
 
-## Quick Setup
+## Quick start
 
-Clone the repository using the following command (replace `<project-name>` 
-with the name of your project):
-
-```bash
-git clone https://github.com/braboj/demo-sensor-app <project-name>
-```
-
-For a specific branch, use the following command:
+Clone the repository and start the full stack:
 
 ```bash
-git clone -b <branch-name> https://github.com/braboj/demo-sensor-app <project-name>
-```
-
-Navigate to the project folder and run the following command to start 
-the application:
-
-```bash
+git clone https://github.com/braboj/demo-sensor-app
+cd demo-sensor-app
 docker compose up
 ```
 
-The following services will be started (plus a PostgreSQL database, a
-one-shot migration step, and the data-generator worker):
+This starts the frontend, backend, a PostgreSQL database, a one-shot migration
+step, the data-generator worker, and Grafana:
 
 - [Frontend (Angular) / localhost:4200](http://localhost:4200)
 - [Backend (Flask) / localhost:5000](http://localhost:5000)
 - [Grafana / localhost:3000](http://localhost:3000)
 
-Grafana ships with a PostgreSQL datasource and a "Sensor Readings" dashboard
+Grafana ships with a PostgreSQL datasource and the "Sensor Readings" dashboard
 provisioned as code (`deploy/grafana/provisioning/`). Log in with `admin` /
 `admin` (override via `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`).
 
-The backend exposes a versioned endpoint to retrieve sensor data:
+## Usage
+
+Fetch the most recent readings (the last 100 by default):
 
 ```bash
 curl http://localhost:5000/api/v1/sensors
 ```
 
-By default, the last 100 records are returned. You can specify the number of
-records to return by passing a query parameter (a bounded integer, 1-100; a
-non-integer or out-of-range value returns `400`):
-
-```bash
-curl http://localhost:5000/api/v1/sensors?limit=1
+```json
+[
+  {
+    "id": 1940,
+    "timestamp": "2026-07-01T06:27:14.147279+00:00",
+    "temperature": 4.4,
+    "humidity": 93.14,
+    "vibration": 0
+  },
+  {
+    "id": 1939,
+    "timestamp": "2026-07-01T06:27:04.139090+00:00",
+    "temperature": 11.32,
+    "humidity": 92.68,
+    "vibration": 1
+  }
+]
 ```
 
-For live updates, the dashboard subscribes to a Server-Sent Events stream
-instead of re-polling; new readings appear automatically as they are
-recorded (see [ADR-0005](docs/decisions/0005-realtime-delivery-sse.md)):
+Vibration is a coded value: `0` = none, `1` = detected.
+
+Bound the result with `?limit=` (an integer 1–100; a non-integer or
+out-of-range value returns `400`, never a silent fallback):
+
+```bash
+curl "http://localhost:5000/api/v1/sensors?limit=1"
+```
+
+Subscribe to the live stream (Server-Sent Events) — new readings arrive as they
+are recorded (see [ADR-0005](docs/decisions/0005-realtime-delivery-sse.md)):
 
 ```bash
 curl -N http://localhost:5000/api/v1/sensors/stream
 ```
 
-Operational endpoints: `GET /health` (liveness — 200 if the process is up)
-and `GET /ready` (readiness — 200 if the database is reachable, else 503).
+Operational endpoints: `GET /health` (liveness — 200 if the process is up) and
+`GET /ready` (readiness — 200 if the database is reachable, else 503).
 
-## Next Steps
+## Deploy
+
+The repo ships a [`render.yaml`](render.yaml) blueprint that runs the whole
+stack on Render's free tier — managed Postgres, the Dockerized backend, the
+static frontend, and Grafana. The live demo above runs from this blueprint. See
+[Deploy](docs/DEPLOY.md) for the walkthrough and the free-tier caveats.
+
+## Next steps
 
 - To set up a dev environment, see [Onboarding](docs/ONBOARDING.md)
 - For day-to-day commands, see the [Playbook](docs/PLAYBOOK.md)
 - To deploy on Render (free tier), see [Deploy](docs/DEPLOY.md)
-- To learn more about the project, please visit [Assignment](docs/history/ASSIGNMENT.md)
-- To read about the solution, please visit [Solution](docs/history/SOLUTION.md)
-- To contribute, please visit [Contributing](CONTRIBUTING.md)
-- To leave feedback, please visit [Discussions](https://github.com/braboj/demo-sensor-app/discussions)
+- To learn more about the project, see the [Assignment](docs/history/ASSIGNMENT.md)
+- To read about the solution, see the [Solution](docs/history/SOLUTION.md)
+- To contribute, see [Contributing](CONTRIBUTING.md)
+- To leave feedback, visit [Discussions](https://github.com/braboj/demo-sensor-app/discussions)

--- a/README.md
+++ b/README.md
@@ -108,20 +108,20 @@ Operational endpoints: `GET /health` (liveness — 200 if the process is up) and
 
 ## Project structure
 
-```text
-backend/                # Flask REST API + data-generator worker
-  src/sensor_api/       # app factory, config, blueprints (sensors, health), worker
-  migrations/           # Alembic migrations
-  tests/                # pytest suite
-frontend/               # Angular SPA (standalone components)
-  src/app/home/         # live readings table + SSE
-  src/app/charts/       # embedded Grafana dashboard
-  src/environments/     # API / Grafana URLs (dev + prod)
-deploy/grafana/         # Grafana image + datasource/dashboard provisioned as code
-docs/                   # ONBOARDING, PLAYBOOK, DEPLOY, decisions (ADRs), history
-docker-compose.yml      # full local stack (backend, frontend, db, grafana, worker)
-render.yaml             # Render free-tier blueprint
-```
+| Path | Purpose |
+|------|---------|
+| `backend/` | Flask REST API + data-generator worker |
+| `backend/src/sensor_api/` | App factory, config, blueprints (sensors, health), worker |
+| `backend/migrations/` | Alembic migrations |
+| `backend/tests/` | pytest suite |
+| `frontend/` | Angular SPA (standalone components) |
+| `frontend/src/app/home/` | Live readings table + SSE |
+| `frontend/src/app/charts/` | Embedded Grafana dashboard |
+| `frontend/src/environments/` | API / Grafana URLs (dev + prod) |
+| `deploy/grafana/` | Grafana image + datasource/dashboard provisioned as code |
+| `docs/` | ONBOARDING, PLAYBOOK, DEPLOY, decisions (ADRs), history |
+| `docker-compose.yml` | Full local stack (backend, frontend, db, grafana, worker) |
+| `render.yaml` | Render free-tier blueprint |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/braboj/demo-sensor-app/actions/workflows/codeql.yml)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 
 # Sensor Dashboard
 
@@ -32,14 +33,12 @@ cold-start for ~30–60s.
 - **Deployable** — a free-tier [Render blueprint](render.yaml) runs the whole
   stack (see [Deploy](docs/DEPLOY.md)).
 
-## Requirements
+## Quick start
 
-To run the application, install:
+Prerequisites:
 
 - [Docker](https://docs.docker.com/engine/install/)
 - [git](https://git-scm.com/downloads)
-
-## Quick start
 
 Clone the repository and start the full stack:
 
@@ -107,6 +106,72 @@ curl -N http://localhost:5000/api/v1/sensors/stream
 Operational endpoints: `GET /health` (liveness — 200 if the process is up) and
 `GET /ready` (readiness — 200 if the database is reachable, else 503).
 
+## Project structure
+
+```text
+backend/                # Flask REST API + data-generator worker
+  src/sensor_api/       # app factory, config, blueprints (sensors, health), worker
+  migrations/           # Alembic migrations
+  tests/                # pytest suite
+frontend/               # Angular SPA (standalone components)
+  src/app/home/         # live readings table + SSE
+  src/app/charts/       # embedded Grafana dashboard
+  src/environments/     # API / Grafana URLs (dev + prod)
+deploy/grafana/         # Grafana image + datasource/dashboard provisioned as code
+docs/                   # ONBOARDING, PLAYBOOK, DEPLOY, decisions (ADRs), history
+docker-compose.yml      # full local stack (backend, frontend, db, grafana, worker)
+render.yaml             # Render free-tier blueprint
+```
+
+## Development
+
+`docker compose up` (above) runs the whole stack. To work on a service on its
+own — PostgreSQL is the only external dependency (`docker compose up db` starts
+one):
+
+Backend (Python 3.12, from `backend/`):
+
+```bash
+pip install -r requirements.txt
+pytest && mypy src --strict          # tests + strict type check
+flask --app sensor_api run           # dev server (needs a reachable PostgreSQL)
+python -m sensor_api.worker          # run the data generator
+```
+
+Frontend (Node 22, from `frontend/`):
+
+```bash
+npm ci
+npm start                            # ng serve on :4200
+npm test && npx eslint .             # unit tests + lint
+```
+
+The backend reads its configuration from environment variables — copy the
+committed `backend/.env.example` to `backend/.env` and adjust. See
+[Onboarding](docs/ONBOARDING.md) for full setup and [Playbook](docs/PLAYBOOK.md)
+for day-to-day commands.
+
+## Configuration
+
+Services are configured through environment variables (documented in
+`backend/.env.example` and [`docker-compose.yml`](docker-compose.yml)); the most
+important:
+
+| Variable | Service | Default | Description |
+|----------|---------|---------|-------------|
+| `DATABASE_URL` | backend, grafana | — | PostgreSQL connection string. |
+| `SECRET_KEY` | backend | — | Flask secret key (**sensitive** — set your own). |
+| `CORS_ORIGINS` | backend | — | Allowed frontend origin (never `*`). |
+| `APP_CONFIG` | backend | `production` | Config profile (`development` / `production`). |
+| `SAMPLE_INTERVAL_SECONDS` | backend, worker | `10` | Generator sample interval. |
+| `RUN_INPROCESS_GENERATOR` | backend | `false` | Run the generator in-process (free-tier only). |
+| `WEB_CONCURRENCY` | backend | `1` | gunicorn worker count. |
+| `API_URL` | frontend (build) | same-origin `/api/v1/sensors` | Absolute backend URL baked into the bundle. |
+| `GRAFANA_URL` | frontend (build) | empty | Grafana dashboard URL for the Charts view. |
+| `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` | grafana | — | Local admin login (**sensitive**). |
+
+See [Deploy](docs/DEPLOY.md) for the full deployment variable set.
+
 ## Deploy
 
 The repo ships a [`render.yaml`](render.yaml) blueprint that runs the whole
@@ -123,3 +188,7 @@ static frontend, and Grafana. The live demo above runs from this blueprint. See
 - To read about the solution, see the [Solution](docs/history/SOLUTION.md)
 - To contribute, see [Contributing](CONTRIBUTING.md)
 - To leave feedback, visit [Discussions](https://github.com/braboj/demo-sensor-app/discussions)
+
+## License
+
+Released into the public domain under [The Unlicense](LICENSE).

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ step, the data-generator worker, and Grafana:
 - [Grafana / localhost:3000](http://localhost:3000)
 
 Grafana ships with a PostgreSQL datasource and the "Sensor Readings" dashboard
-provisioned as code (`deploy/grafana/provisioning/`). Log in with `admin` /
-`admin` (override via `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD`).
+provisioned as code (`deploy/grafana/provisioning/`). The admin login is set via
+the `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` environment variables (see
+`docker-compose.yml`) — set your own before exposing Grafana beyond local use.
 
 ## Usage
 


### PR DESCRIPTION
Reworks the README to be demo-ready **and** structurally aligned with the `base/core/readme.md` template. Addresses issue #11 (review the README).

## Polish
- Real title `# Sensor Dashboard` + tagline (was `# Introduction`).
- **Live demo link** headlined (frontend; Live Table + Charts tabs) with the cold-start caveat.
- CI + CodeQL + License badges.
- **Features** capability list; **sample API response** with a vibration legend.

## Security fix
- Removed the published Grafana `admin`/`admin` default — the README now references the `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` env-var names only. (Local default; the live Grafana uses a generated password + anonymous view. gitleaks was green — this was a docs-hygiene issue, not a leak.)

## Template-structure alignment
Adds the template's required sections that were missing, in order:
- **Project structure** — top-two-levels tree.
- **Development** — per-service setup + external services + `.env.example` pointer.
- **Configuration** — env-var reference table (sensitive keys flagged, no real values).
- **License** — The Unlicense, as the final section.

Deep detail still defers to `docs/ONBOARDING.md` / `docs/PLAYBOOK.md` / `docs/DEPLOY.md` per the template's "move deep reference to docs/" rule. All referenced links verified; no decorative `---` rules.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
