### PR TITLE
chore(frontend): modernize tsconfig.json to Angular 19 defaults

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -14,18 +13,16 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "useDefineForClassFields": false,
     "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true,
-    "_enabledBlockTypes": ["if", "for"]
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
## Summary

Clears stale/obsolete compiler options in `frontend/tsconfig.json` that predate the Angular 19 / TypeScript 5.6 upgrade. None of these broke the build (`tsc --noEmit` already exited 0) — this is config modernization, not a bug fix.

| Change | Why |
|--------|-----|
| Remove `_enabledBlockTypes: ["if", "for"]` | Obsolete Angular-17 internal flag; `@if`/`@for`/`@switch` are stable and enabled by default in v19 (the flag also omitted `switch`). This was the main editor warning. |
| Remove `baseUrl: "./"` | Dropped from Angular's default tsconfig in v16; no `paths` mapping relies on it. |
| `moduleResolution: "node"` → `"bundler"` | `"bundler"` is the Angular 19 `ng new` default; `node` (node10) is legacy. |
| Remove `useDefineForClassFields: false` | Modern generated config omits it and relies on the `target: ES2022` default (`true`). Verified nothing regresses. |

Scope kept to the four flagged options — no unrelated tsconfig churn.

## Verification

- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `npx tsc --noEmit -p tsconfig.spec.json` — clean
- `npm run build` — ✔ bundle generated
- `npm test` — 22/22 SUCCESS (Chrome Headless)
- `npx eslint .` — exit 0

## Acceptance criteria

- [x] Editor warnings on `frontend/tsconfig.json` cleared
- [x] `npm run build`, `npm test`, `npx eslint .` remain green
- [x] Options match the Angular 19 generated defaults where practical

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)