### PR TITLE
docs(adr): ADR-0009 — Render deploy hook trigger vs autoDeploy (spike #59)

### DIFF
--- a/docs/decisions/0009-render-deploy-hook-trigger.md
+++ b/docs/decisions/0009-render-deploy-hook-trigger.md
@@ -1,0 +1,86 @@
+# ADR-0009 — Trigger Render deploys with a CI deploy hook, not push-based autoDeploy
+
+**Status:** Accepted (2026-07-01, spike #59)
+
+## Context
+The Render Blueprint (`render.yaml`, shipped in #55) deploys the live stack —
+managed Postgres plus three web services (`sensor-app-backend`,
+`sensor-app-frontend`, `sensor-app-grafana`) — with `autoDeploy: true` on every
+service. Every push to `main` triggers a Render build + deploy through Render's
+GitHub webhook, **regardless of CI status**: a push that fails CI still
+redeploys, and the deploy is not an observable step anywhere in the pipeline.
+
+The sibling project `braboj/demo-randomgen` moved away from this model in its
+[AD-17](https://github.com/braboj/demo-randomgen/blob/main/docs/decisions/017-render-image-deploy-hook.md).
+That ADR records two first-hand drivers:
+
+- **(a) Reliability / observability** — commit-based `autoDeploy` "did not fire
+  reliably," so the demo lagged the released code, and nothing made a deploy an
+  explicit step.
+- **(b) Double build** — randomgen's release workflow already builds and pushes
+  an image to Docker Hub, so Render was rebuilding the same artifact a second
+  time. AD-17 fixed both by switching Render to `runtime: image` and POSTing a
+  deploy hook on each release tag.
+
+Two sensor_app-specific facts reshape how AD-17 applies:
+
+- **Driver (b) does not exist here.** sensor_app's CI publishes no image and has
+  no release/tagging process, so there is no CI-built artifact for Render to
+  double-build. Only driver (a) — unreliable, un-gated deploys — is a real
+  problem for this project.
+- **The deploy surface is heterogeneous.** sensor_app has three deploy targets,
+  and the **frontend is a Render static site** (Render builds it from source);
+  it cannot use the `runtime: image` model at all. The backend and grafana are
+  Docker services and *could* pull published images, but doing so for only two
+  of three services would create a split deploy model.
+
+## Decision
+Adopt **the deploy-hook trigger, keeping Render's build** (spike Option 1):
+
+- Set **`autoDeploy: false`** on all three web services in `render.yaml`. Render
+  keeps building each service from source (backend Dockerfile, frontend static
+  build, grafana Dockerfile) — no registry publishing is introduced.
+- Add a **`deploy` job to `ci.yml`** that runs only on `push` to `main`, is
+  gated `needs: [backend, frontend]` so a red pipeline never deploys, and POSTs
+  one Render deploy hook per service. Each POST is **skipped when its secret is
+  unset**, so the workflow stays green before the hooks exist and on
+  forks / pull requests.
+- The three deploy-hook URLs are **GitHub Actions secrets** created once in the
+  Render dashboard after the Blueprint is applied:
+  `RENDER_DEPLOY_HOOK_BACKEND`, `RENDER_DEPLOY_HOOK_FRONTEND`,
+  `RENDER_DEPLOY_HOOK_GRAFANA`.
+
+This is the smallest change that fixes driver (a): a deploy becomes an explicit,
+observable, CI-gated step, and the hook trigger is build-model-agnostic, so it
+applies uniformly to the Docker and static services alike. Implementation is
+tracked in **#88** (this spike lands only the decision).
+
+## Alternatives considered
+- **Full randomgen pattern (`runtime: image` + registry publish + release-tag
+  deploy)** — rejected. Its core driver (avoiding a double build) is moot here,
+  it adds registry secrets and a release/tagging workflow sensor_app does not
+  have, and the static frontend cannot participate — yielding a split-brain
+  deploy model for marginal benefit on a zero-cost demo.
+- **Keep `autoDeploy: true`** — rejected. It preserves exactly the reliability
+  gap AD-17 documented and keeps deploying on red-CI pushes, with no observable
+  deploy step.
+
+## Consequences
+- **Deploys are CI-gated and observable.** A push to `main` deploys only after
+  its checks pass, and the deploy shows as a job in Actions (green/red) rather
+  than an opaque Render webhook. A red pipeline no longer ships.
+- **One-time setup** is required before deploys resume: apply the Blueprint,
+  create a Deploy Hook per service in Render, and store the three URLs as GitHub
+  secrets. Until then the `deploy` steps skip and CI stays green.
+- **CodeQL cannot gate the deploy job.** It runs in a separate workflow, and
+  cross-workflow `needs:` is not supported; the deploy job gates on the `ci.yml`
+  jobs, and branch protection continues to enforce CodeQL as a required check
+  before merge to `main`.
+- **Every green `main` commit deploys, including docs-only commits.** Accepted
+  for a demo; if the redeploy noise (free-tier cold starts) becomes a problem, a
+  path filter on the deploy job is a cheap follow-up refinement.
+- **The cross-service URL caveat is unchanged** — `CORS_ORIGINS`, `API_URL`,
+  `GRAFANA_URL`, and `GF_SERVER_ROOT_URL` must still match the real service URLs
+  (see `docs/DEPLOY.md`).
+- Refs: randomgen AD-17, #55 (Blueprint), ADR-0004 / ADR-0007 (Render stack),
+  epic #12; implementation in #88.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -7,3 +7,8 @@ numbered. Format: Status / Context / Decision / Consequences.
 - [ADR-0002](0002-ci-gates-green-subset.md) — CI gates only currently-green checks; strict gates phase in
 - [ADR-0003](0003-frontend-nginx-same-origin-proxy.md) — Production frontend served by nginx with a same-origin /api proxy
 - [ADR-0004](0004-inprocess-generator-free-tier.md) — In-process data generator on the free hosting tier (Render)
+- [ADR-0005](0005-realtime-delivery-sse.md) — Real-time delivery via Server-Sent Events
+- [ADR-0006](0006-gate-mypy-strict.md) — Gate CI on mypy --strict
+- [ADR-0007](0007-deploy-grafana-on-render.md) — Deploy Grafana to the live Render stack
+- [ADR-0008](0008-embed-grafana-in-spa.md) — Embed the Grafana dashboard in the SPA
+- [ADR-0009](0009-render-deploy-hook-trigger.md) — Trigger Render deploys with a CI deploy hook, not push-based autoDeploy


### PR DESCRIPTION
## Summary

Resolves the **spike #59** — evaluate whether to align sensor_app's Render deploy trigger with the `randomgen` AD-17 pattern. Output is the decision (ADR-0009); the implementation is deferred to a follow-up ticket, per the spike's acceptance criteria.

## Decision (Option 1 — deploy hook, keep Render build)

Set `autoDeploy: false` on all three web services and POST a per-service Render deploy hook from a new CI job gated on green checks on `main`.

**Why not the full randomgen pattern (Option 2):** AD-17 had two drivers — (a) unreliable, un-gated `autoDeploy`, and (b) Render double-building an image CI already published. Only **(a) applies to sensor_app** — this repo publishes no image and has no release process, so there's no double build to eliminate. Meanwhile the **frontend is a Render static site** and can't use `runtime: image` at all, so Option 2 would create a split deploy model for marginal benefit. Option 1 fixes (a) with the smallest change and ports uniformly to all three services.

**Why not keep `autoDeploy: true` (Option 3):** it preserves the exact reliability gap AD-17 documented and keeps deploying even on red CI.

## Changes

- Add `docs/decisions/0009-render-deploy-hook-trigger.md` (Status / Context / Decision / Alternatives / Consequences), referencing randomgen AD-17.
- Fill the ADR index in `docs/decisions/README.md` — it listed only 0001–0004; adds 0005–0009.

## Acceptance criteria

- [x] Decision recorded as an ADR in `docs/decisions/`, referencing randomgen AD-17.
- [x] Follow-up implementation ticket opened — #88 (covers the `render.yaml` edit, the CI deploy step, and the three GH secrets).

## Notes

Docs-only PR — no code paths touched. Follow-up #88 carries the actual `render.yaml` + `ci.yml` changes.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)